### PR TITLE
moved max_tls_version property from top level to /router

### DIFF
--- a/bosh/opsfiles/router-logstash.yml
+++ b/bosh/opsfiles/router-logstash.yml
@@ -123,5 +123,5 @@
           value: "DENY"
 
 - type: replace
-  path: /instance_groups/name=router-logstash/jobs/name=gorouter/properties/max_tls_version?
+  path: /instance_groups/name=router-logstash/jobs/name=gorouter/properties/router/max_tls_version?
   value: TLSv1.3

--- a/bosh/opsfiles/router-main.yml
+++ b/bosh/opsfiles/router-main.yml
@@ -123,5 +123,5 @@
           value: "DENY"
 
 - type: replace
-  path: /instance_groups/name=router-main/jobs/name=gorouter/properties/max_tls_version?
+  path: /instance_groups/name=router-main/jobs/name=gorouter/properties/router/max_tls_version?
   value: TLSv1.3

--- a/bosh/opsfiles/routing.yml
+++ b/bosh/opsfiles/routing.yml
@@ -7,5 +7,5 @@
   value: 3600
 
 - type: replace
-  path: /instance_groups/name=router/jobs/name=gorouter/properties/max_tls_version?
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/max_tls_version?
   value: TLSv1.3


### PR DESCRIPTION
## Changes proposed in this pull request:
- moved the max_tls_version property to /router
-
-

## security considerations
None