### PR TITLE
Document purpose of terraform-yaml resource in terraform jobs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -177,9 +177,6 @@ jobs:
             resource: src
             trigger: false
             passed: [set-self]
-          - get: terraform-yaml
-            resource: terraform-yaml-development
-            trigger: true
           - get: pipeline-tasks
           - get: general-task
       - task: terraform-plan
@@ -859,9 +856,6 @@ jobs:
             resource: terraform-config
             trigger: true
             passed: [terraform-apply-development]
-          - get: terraform-yaml
-            resource: terraform-yaml-staging
-            trigger: true
           - get: pipeline-tasks
           - get: general-task
       - task: terraform-plan
@@ -1436,9 +1430,6 @@ jobs:
           - get: terraform-templates
             resource: terraform-config
             passed: [acceptance-tests-staging]
-            trigger: true
-          - get: terraform-yaml
-            resource: terraform-yaml-production
             trigger: true
           - get: pipeline-tasks
           - get: general-task

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -177,6 +177,9 @@ jobs:
             resource: src
             trigger: false
             passed: [set-self]
+          # Changes to the iaas state file trigger a build. This is not a step
+          # input because the state is accessed separately using a
+          # terraform_remote_state data source.
           - get: terraform-yaml
             resource: terraform-yaml-development
             trigger: true
@@ -859,6 +862,9 @@ jobs:
             resource: terraform-config
             trigger: true
             passed: [terraform-apply-development]
+          # Changes to the iaas state file trigger a build. This is not a step
+          # input because the state is accessed separately using a
+          # terraform_remote_state data source.
           - get: terraform-yaml
             resource: terraform-yaml-staging
             trigger: true
@@ -1437,6 +1443,9 @@ jobs:
             resource: terraform-config
             passed: [acceptance-tests-staging]
             trigger: true
+          # Changes to the iaas state file trigger a build. This is not a step
+          # input because the state is accessed separately using a
+          # terraform_remote_state data source.
           - get: terraform-yaml
             resource: terraform-yaml-production
             trigger: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -177,6 +177,9 @@ jobs:
             resource: src
             trigger: false
             passed: [set-self]
+          - get: terraform-yaml
+            resource: terraform-yaml-development
+            trigger: true
           - get: pipeline-tasks
           - get: general-task
       - task: terraform-plan
@@ -856,6 +859,9 @@ jobs:
             resource: terraform-config
             trigger: true
             passed: [terraform-apply-development]
+          - get: terraform-yaml
+            resource: terraform-yaml-staging
+            trigger: true
           - get: pipeline-tasks
           - get: general-task
       - task: terraform-plan
@@ -1430,6 +1436,9 @@ jobs:
           - get: terraform-templates
             resource: terraform-config
             passed: [acceptance-tests-staging]
+            trigger: true
+          - get: terraform-yaml
+            resource: terraform-yaml-production
             trigger: true
           - get: pipeline-tasks
           - get: general-task


### PR DESCRIPTION
## Changes proposed in this pull request:
- ~I _think_ this input is unused. If an operator knows why it's there, let me know and I'll keep it, and add a comment explaining its purpose. In the deploy-cf jobs, it's used by the `terraform-secrets` steps, but I cannot find any step that takes it as an input in the terraform jobs.~
- The input is used to trigger the jobs, but not used as an input to the jobs. This PR documents the setup.

## security considerations

None. Removing unused code.