### PR TITLE
Add s3 backend to apps stack and make it more obvious in cf stack

### DIFF
--- a/terraform/stacks/apps/providers.tf
+++ b/terraform/stacks/apps/providers.tf
@@ -1,2 +1,7 @@
+terraform {
+  backend "s3" {
+  }
+}
+
 provider "cloudfoundry" {
 }

--- a/terraform/stacks/cf/asg.tf
+++ b/terraform/stacks/cf/asg.tf
@@ -1,8 +1,3 @@
-terraform {
-  backend "s3" {
-  }
-}
-
 resource "cloudfoundry_asg" "public_networks" {
   name = "public_networks"
 
@@ -66,14 +61,14 @@ resource "cloudfoundry_asg" "public_networks_egress" {
     description = "Rule for private endpoint to s3 in region"
     protocol    = "tcp"
     destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if1_ip
-    ports="443"
+    ports       = "443"
   }
 
-  rule{
+  rule {
     description = "Rule for private endpoint to s3 in region"
     protocol    = "tcp"
     destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if2_ip
-    ports="443"
+    ports       = "443"
   }
 
 }
@@ -321,17 +316,17 @@ resource "cloudfoundry_asg" "internal_services_egress" {
 
 # Default global running ASG
 resource "cloudfoundry_default_asg" "running" {
-    name = "running"
-    asgs = [ cloudfoundry_asg.dns.id ]
+  name = "running"
+  asgs = [cloudfoundry_asg.dns.id]
 }
 
 # Default global staging ASG
 resource "cloudfoundry_default_asg" "staging" {
-    name = "staging"
-    asgs = [
-      cloudfoundry_asg.dns.id,
-      cloudfoundry_asg.public_networks_egress.id,
-      cloudfoundry_asg.trusted_local_networks_egress.id,
-    ]
+  name = "staging"
+  asgs = [
+    cloudfoundry_asg.dns.id,
+    cloudfoundry_asg.public_networks_egress.id,
+    cloudfoundry_asg.trusted_local_networks_egress.id,
+  ]
 }
 

--- a/terraform/stacks/cf/providers.tf
+++ b/terraform/stacks/cf/providers.tf
@@ -1,2 +1,7 @@
+terraform {
+  backend "s3" {
+  }
+}
+
 provider "cloudfoundry" {
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixes the stack only saving state locally in Concourse.
- Also includes a few formatting fixes.

## security considerations

None. Standard terraform practice.