### PR TITLE
Watch the CSB image in ECR for changes and deploy by digest

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -246,6 +246,10 @@ jobs:
             trigger: true
           - get: pipeline-tasks
           - get: general-task
+          - get: csb-image
+            trigger: true
+      - load_var: csb-image-digest
+        file: csb-image/digest
       - task: terraform-plan
         image: general-task
         file: terraform-templates/terraform/terraform-apply.yml
@@ -263,6 +267,7 @@ jobs:
           TF_VAR_csb_broker_route_domain: ((csb-broker-route-domain-development))
           TF_VAR_csb_cg_smtp_aws_ses_zone: appmail.dev.us-gov-west-1.aws-us-gov.cloud.gov
           TF_VAR_csb_docker_image_name: ((csb-docker-image-name))
+          TF_VAR_csb_docker_image_version: "@((.:csb-image-digest))"
           TF_VAR_csb_org_name: ((csb-org-name))
           TF_VAR_csb_space_name: ((csb-space-name))
           TF_VAR_external_remote_state_reader_access_key_id: ((development-tf-state-access-key-id))
@@ -1944,6 +1949,15 @@ resources:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
       repository: general-task
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: csb-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: csb
       aws_region: us-gov-west-1
       tag: latest
 

--- a/terraform/stacks/apps/apps.tf
+++ b/terraform/stacks/apps/apps.tf
@@ -22,8 +22,9 @@ module "csb" {
   aws_secret_access_key_commercial = data.terraform_remote_state.external.outputs.csb.broker_user.secret_access_key_curr
   aws_region_commercial            = var.csb_aws_region_commercial
 
-  org_name            = var.csb_org_name
-  space_name          = var.csb_space_name
-  docker_image_name   = var.csb_docker_image_name
-  broker_route_domain = var.csb_broker_route_domain
+  org_name             = var.csb_org_name
+  space_name           = var.csb_space_name
+  docker_image_name    = var.csb_docker_image_name
+  docker_image_version = var.csb_docker_image_version
+  broker_route_domain  = var.csb_broker_route_domain
 }

--- a/terraform/stacks/apps/variables.tf
+++ b/terraform/stacks/apps/variables.tf
@@ -49,6 +49,10 @@ variable "csb_docker_image_name" {
   type = string
 }
 
+variable "csb_docker_image_version" {
+  type = string
+}
+
 variable "csb_org_name" {
   type = string
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add only to dev to start
- With this change, new versions of the image will automatically trigger a terraform plan
- Using a floating tag like "latest" is bad practice; using the digest will make it easier to track which image is in use

## security considerations

Improves security by ensuring we always run the most recently built version of the CSB. (In dev, to start.)