### PR TITLE
Bumping fastapi version to work with newer starlette version

### DIFF
--- a/ci/test-space-egress/requirements.txt
+++ b/ci/test-space-egress/requirements.txt
@@ -4,7 +4,7 @@ certifi==2024.7.4
 cfenv==0.5.3
 charset-normalizer==2.0.4
 click==8.0.1
-fastapi==0.111.0
+fastapi==0.115.4
 furl==2.1.3
 h11==0.12.0
 idna==3.7


### PR DESCRIPTION
## Changes proposed in this pull request:
- Bump fastapi to a version that does not conflict with starlette
- Part of platform maintenance: https://github.com/cloud-gov/private/issues/618
-

## security considerations
Just patching dependencies
