### PR TITLE
Update OpenSearch UAA clients

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -131,16 +131,30 @@
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/opensearch-dashboards-proxy-ci?
   value:
     override: true
-    scope: cloud_controller.read openid scim.read
-    authorized-grant-types: refresh_token client_credentials authorization_code
-    authorities: scim.read
-    redirect-uri: ((redirect_uri))
+    authorized-grant-types: client_credentials
+    authorities: scim.write,uaa.admin,password.write
     secret: ((opensearch-dashboards-proxy-ci-secret))
 
 - type: replace
   path: /variables/-
   value:
     name: opensearch-dashboards-proxy-ci-secret
+    type: password
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/opensearch_dashboards_proxy?
+  value:
+    override: true
+    scope: cloud_controller.read,openid,scim.read
+    authorized-grant-types: refresh_token,authorization_code
+    authorities: scim.read
+    redirect-uri: ((opensearch_dashboards_proxy_redirect_uri))
+    secret: ((opensearch-dashboards-proxy-secret))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: opensearch-dashboards-proxy-secret
     type: password
 
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:

- update authorities and grant types for opensearch-dashboards-proxy-ci client, which is only used by CI for making password updates to test users in UAA
- add opensearch_dashboards_proxy client which is the client used by the proxy deployed with OpenSearch to handle communicating with UAA. We were previously managing this client manually, but this adds it to versional control for better visibility and maintenance

## security considerations

Limiting permissions of opensearch-dashboards-proxy-ci to only what is necessary is good for security. There are no material changes to the permissions for the opensearch_dashboards_proxy client, just adding it to version control
