### PR TITLE
update security groups for opensearch dashboards proxy testing space

### DIFF
--- a/terraform/stacks/cf/spaces.tf
+++ b/terraform/stacks/cf/spaces.tf
@@ -86,9 +86,11 @@ resource "cloudfoundry_space" "opensearch-dashboards-proxy" {
   asgs = [
     cloudfoundry_asg.public_networks_egress.id,
     cloudfoundry_asg.dns.id,
+    cloudfoundry_asg.trusted_local_networks.id
   ]
   staging_asgs = [
     cloudfoundry_asg.dns.id,
+    cloudfoundry_asg.public_networks_egress.id
   ]
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- update security groups for opensearch dashboards proxy testing space to allow communicating with brokered services

## security considerations

Allowing traffic to reach brokered services from this space
