### PR TITLE
update opensearch dashboards proxy client

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -146,7 +146,7 @@
   value:
     override: true
     scope: cloud_controller.read,openid,scim.read
-    authorized-grant-types: refresh_token,authorization_code
+    authorized-grant-types: refresh_token,authorization_code,client_credentials
     authorities: scim.read
     redirect-uri: ((opensearch_dashboards_proxy_redirect_uri))
     secret: ((opensearch-dashboards-proxy-secret))


### PR DESCRIPTION
## Changes proposed in this pull request:

- add client_credentials authorized grant type for opensearch dashboards proxy UAA client

## security considerations

This client needs these permissions since the proxy uses the client_credentials flow to make requests to UAA
