### PR TITLE
Remove meta-data-v2 vm_extension, set globally in CPI

### DIFF
--- a/bosh/opsfiles/meta-data-v2-diego-cell.yml
+++ b/bosh/opsfiles/meta-data-v2-diego-cell.yml
@@ -1,7 +1,0 @@
-# NOTES:
-# - This ops file is used for ALL diego cell and isolation segments with ci/create-*-diego-cell.sh
-# - This ops file can ONLY contain configurations for `path: /instance_groups/name=diego-cell/`
-
-- type: replace
-  path: /instance_groups/name=diego-cell/vm_extensions/-
-  value: meta-data-v2

--- a/ci/create-diego-cell-iso-seg.sh
+++ b/ci/create-diego-cell-iso-seg.sh
@@ -15,7 +15,6 @@ bosh int \
   -o cf-manifests/bosh/opsfiles/diego-cell-disk.yml \
   -o cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml \
   -o cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml \
-  -o cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml \
   -o cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml \
   --path /instance_groups/name=diego-cell > diego-cell_raw.yml
 

--- a/ci/create-diego-platform-cell.sh
+++ b/ci/create-diego-platform-cell.sh
@@ -11,7 +11,6 @@ bosh int \
   -o cf-manifests/bosh/opsfiles/diego-cell-disk.yml \
   -o cf-manifests/bosh/opsfiles/disable-secure-service-credentials-diego-cell.yml \
   -o cf-manifests/bosh/opsfiles/diego-rds-certs-diego-cell.yml \
-  -o cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml \
   -o cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml \
   --path /instance_groups/name=diego-cell > diego-cell_raw.yml
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -105,7 +105,6 @@ jobs:
             - cf-manifests/bosh/opsfiles/rds-ca.yml
             - cf-manifests/bosh/opsfiles/content-security-policy.yml
             - cf-manifests/bosh/opsfiles/loggregator.yml
-            - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
             - cf-manifests/bosh/opsfiles/router-main.yml
             - cf-manifests/bosh/opsfiles/router-main-dev.yml
             - cf-manifests/bosh/opsfiles/router-logstash.yml
@@ -739,7 +738,6 @@ jobs:
             - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
             - cf-manifests/bosh/opsfiles/rds-ca.yml
             - cf-manifests/bosh/opsfiles/loggregator.yml
-            - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
             - cf-manifests/bosh/opsfiles/router-main.yml
             - cf-manifests/bosh/opsfiles/router-logstash.yml
             - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
@@ -1362,7 +1360,6 @@ jobs:
             - cf-manifests/bosh/opsfiles/uaa-rds-ca.yml
             - cf-manifests/bosh/opsfiles/rds-ca.yml
             - cf-manifests/bosh/opsfiles/loggregator.yml
-            - cf-manifests/bosh/opsfiles/meta-data-v2-diego-cell.yml
             - cf-manifests/bosh/opsfiles/router-main.yml
             - cf-manifests/bosh/opsfiles/router-logstash.yml
             - cf-manifests/bosh/opsfiles/add-autoscaler-ca.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes the usage of the `meta-data-v2` cloud config vm_extension, this is now configured globally in the BOSH CPI with https://github.com/cloud-gov/deploy-bosh/pull/625
- Part of https://github.com/cloud-gov/private/issues/1911

## security considerations
Continues the use of a token to access metadata information
