### PR TITLE
Standardizing waaaaaaaaaaaaaaazuh dashboard bosh dns

### DIFF
--- a/bosh/opsfiles/wazuh.yml
+++ b/bosh/opsfiles/wazuh.yml
@@ -8,10 +8,10 @@
 - type: replace
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
   value:
-    domain: wazuh.service.cf.internal
+    domain: wazuh-dashboard.service.cf.internal
     targets:
     - deployment: wazuh
       domain: bosh
-      instance_group: wazuh
+      instance_group: wazuh-dashboard
       network: default
       query: '*'


### PR DESCRIPTION
## Changes proposed in this pull request:
- Normalizing the bosh dns entry for the wazuh dashboard
- Continuing to only use this for Dev (and will for a while)
- Part of https://github.com/cloud-gov/private/issues/1995

## security considerations
Fixes a DNS entry lookup 
