### PR TITLE
Enable v2 ops

### DIFF
--- a/bosh/opsfiles/api-defaults.yml
+++ b/bosh/opsfiles/api-defaults.yml
@@ -11,6 +11,11 @@
   value: 7168
 
 - type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/min_recommended_cli_version?
+  value: 7.7.1
+
+
+- type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/maximum_app_disk_in_mb?
   value: 7168
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -69,6 +69,7 @@ jobs:
             - cf-deployment/operations/stop-skipping-tls-validation.yml
             - cf-deployment/operations/set-bbs-active-key.yml
             - cf-deployment/operations/enable-service-discovery.yml
+            - cf-deployment/operations/enable-v2-api.yml
             - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
             - cf-manifests/bosh/opsfiles/clients.yml
             - cf-manifests/bosh/opsfiles/development-clients.yml
@@ -703,6 +704,7 @@ jobs:
             - cf-deployment/operations/stop-skipping-tls-validation.yml
             - cf-deployment/operations/set-bbs-active-key.yml
             - cf-deployment/operations/enable-service-discovery.yml
+            - cf-deployment/operations/enable-v2-api.yml
             - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
             - cf-manifests/bosh/opsfiles/clients.yml
             - cf-manifests/bosh/opsfiles/pages-clients-dev.yml
@@ -1327,6 +1329,7 @@ jobs:
             - cf-deployment/operations/stop-skipping-tls-validation.yml
             - cf-deployment/operations/set-bbs-active-key.yml
             - cf-deployment/operations/enable-service-discovery.yml
+            - cf-deployment/operations/enable-v2-api.yml
             - cf-manifests/bosh/opsfiles/remove-routing-components-for-transition.yml
             - cf-manifests/bosh/opsfiles/clients.yml
             - cf-manifests/bosh/opsfiles/pages-clients-production.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds CF-deployment opsfile to enable v2 api (It is currently default true so this protects us when its default false)
- Adding Min RECOMMENDED api to v7. 

## security considerations
None, v2 would go away soon tm