### PR TITLE
Removing unused /bosh/app-autoscaler/metric_scraper_ca.ca

### DIFF
--- a/bosh/opsfiles/add-autoscaler-ca.yml
+++ b/bosh/opsfiles/add-autoscaler-ca.yml
@@ -1,6 +1,3 @@
 - type: replace
   path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs?/-
   value: ((/bosh/app-autoscaler/app_autoscaler_ca_cert.ca))
-- type: replace
-  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs?/-
-  value: ((/bosh/app-autoscaler/metric_scraper_ca.ca))


### PR DESCRIPTION
## Changes proposed in this pull request:
- CA was identified as expiring by Doomsday, however it isn't used in app-autoscaler (anymore) so no longer needed in CF
- Part of platform maintenance https://github.com/cloud-gov/private/issues/618
-

## security considerations
Removing unused self signed cert
