### PR TITLE
Create a UAA client for deploying the Cloud Service Broker

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -111,6 +111,20 @@
     secret: ((terraform-client-secret))
 
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/deploy-csb?
+  value:
+    override: true
+    authorized-grant-types: client_credentials
+    authorities: cloud_controller.admin
+    secret: ((deploy-csb-client-secret))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: deploy-csb-client-secret
+    type: password
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/uaa-credentials-broker?
   value:
     override: true


### PR DESCRIPTION
## Changes proposed in this pull request:
- The CSB is deployed using Concourse & Terraform in the repo: https://github.com/cloud-gov/csb

## security considerations

Creates a new client with administrative access to Cloud Foundry. Patterned off other clients in the same file. Credentials will be stored security in our credential store.