### PR TITLE
Pin UAA

### DIFF
--- a/bosh/opsfiles/pin-uaa.yml
+++ b/bosh/opsfiles/pin-uaa.yml
@@ -1,0 +1,14 @@
+- type: replace
+  path: /releases/name=uaa
+  value:
+    name: uaa
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=77.20.0
+    version: 77.20.0
+    sha1: b3237de30c42db8628498e71e1f40f4138215c7f
+
+
+- type: replace
+  path:  /releases/name=uaa-customized
+  value:
+    name: uaa-customized
+    version: 59

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -116,6 +116,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/wazuh.yml
+            - cf-manifests/bosh/opsfiles/pin_uaa.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/development.yml
             - terraform-secrets/terraform.yml
@@ -766,6 +767,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
             - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
+            - cf-manifests/bosh/opsfiles/pin_uaa.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/staging.yml
             - terraform-secrets/terraform.yml
@@ -1417,6 +1419,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
             - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
+            - cf-manifests/bosh/opsfiles/pin_uaa.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/production.yml
             - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- This is a temporary ops file to pin the version of UAA to the last known working value but keep the version of cf-deployment that matches prod, this reconciles to put the lower environments in the same configuration
- Part of platform maintenance: https://github.com/cloud-gov/private/issues/618
-

## security considerations
Enforces what we currently have in production
