### PR TITLE
_ != -

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -116,7 +116,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/wazuh.yml
-            - cf-manifests/bosh/opsfiles/pin_uaa.yml
+            - cf-manifests/bosh/opsfiles/pin-uaa.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/development.yml
             - terraform-secrets/terraform.yml
@@ -767,7 +767,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/add-bosh-dns-other-deployments.yml
             - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
-            - cf-manifests/bosh/opsfiles/pin_uaa.yml
+            - cf-manifests/bosh/opsfiles/pin-uaa.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/staging.yml
             - terraform-secrets/terraform.yml
@@ -1419,7 +1419,7 @@ jobs:
             - cf-manifests/bosh/opsfiles/add-opensearch-ca.yml
             - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
-            - cf-manifests/bosh/opsfiles/pin_uaa.yml
+            - cf-manifests/bosh/opsfiles/pin-uaa.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/production.yml
             - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- This is a temporary ops file to pin the version of UAA to the last known working value but keep the version of cf-deployment that matches prod, this reconciles to put the lower environments in the same configuration. 
- This is a syntax fix to https://github.com/cloud-gov/deploy-cf/pull/939
- Part of platform maintenance: https://github.com/cloud-gov/private/issues/618
-

## security considerations
Enforces what we currently have in production
