### PR TITLE
Logs Icon on homepage

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -148,6 +148,11 @@
     scope: cloud_controller.read,openid,scim.read
     authorized-grant-types: refresh_token,authorization_code,client_credentials
     authorities: scim.read
+    name: "Logs"
+    autoapprove: true
+    show-on-homepage: true
+    app-icon: 'iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAAAXNSR0IArs4c6QAAA29JREFUeF7tnGtOxDAMhMPJgJMBJwNOBmu0Ed2qrcdp2kmTWWnFjzpxOp/tPFr2KelDVeCJ6l3OkwCQg0AABICsANm9MkAAyAqQ3SsDBICsANm9MkAAyAqQ3SsDLgrgPaX0nFJ6IY+/FfdfKaXvmx72177wJ5oBJvwb3PuYhh+32zadoE8EgMSHJP0zgiGgACQ+Ln62hCAgAKzOf8b9q8UtE1x9XYN7PVPdL4snNwsQABb9Wu2UAbAV0etWUwTAT5lvtborsKlxDQBIHz3T8AJUAA6mLwAHC+x1LwCeQgdfF4AVgfPmMZ/N2JIwdE4DghOABaGWls7ukhAUfG4mADNFtvYt7saoAIIATERDjk1qQxCACQBk1y4ABWmONEGiP3RSiTi9PR9RBtyF8oSY6lkzCzy/Q+yES55X1IIwPIBI6TkiC4YHgEy8a+W8RhYMDaA0+mtOxkMD2BP9tSDQAYCrtVWzfD6z+eRoofXe6N87brT94asgdCCeXfSsxos882dQDRTzmfZlAJhg6KSILDszUMTWC4491y8FAIGAlh6L/lzemBC6A4BMvPNMEoBgDq+VIiT61+YSFoTLZcBWGUKif1p65tyR9sFYcc0vCWAJAhLB3kpquiI662WzwwGUvBeEiDkvQ+iy84jnvlth7o2rSQB2QxEIiK0X/W6tKDToHoAJi7ydvVX7C7WFml0WAJoFiAroBg7pK2ozPABW6cmgLg2gRhawSo8A3I8aoqeo0RLj2V8+A/ZkATv6bezDAmDX/m5KUL4RZK0/LQctRH83GRAtQ8xl53xO6KIERbKgldLTXQlCs6CV0tMlAA9Ca9Hf1Rwwra1n/oOFt873rnc1B+SbnZ/btzTpdj0Je9HW4vUuM6BFodfGJABkWgIwOgDy/TfvfvczYcarHM2rCg7Q3bcgbzRED8nAsQ1h5i6fEQDIbm8INQtu0j02QQEoC+Lqu9FvXaIAvDOa+PD6bgGJHwUgCFjQwOKXALA2dk5jX/108T+Q/NPF8C/m5qaREoTxl1VIAQEIyVXfWADqaxrqUQBCctU3XgLgne7VH8VYPT5oLgDnwxeA8zV/8CgAAkBWgOxeGSAAZAXI7pUBrQMgj28s99oJk3kLgACQFSC7VwYIAFkBsntlgACQFSC7VwYIAFkBsntlgACQFSC7/wXS9tRhjM55xgAAAABJRU5ErkJggg=='
+    app-launch-url: https://logs.((system_domain))
     redirect-uri: ((opensearch_dashboards_proxy_redirect_uri))
     secret: ((opensearch-dashboards-proxy-secret))
 
@@ -166,7 +171,7 @@
     access-token-validity: 600
     refresh-token-validity: 43200
     name: Logsearch
-    redirect-uri: https://logs.((system_domain))/login
+    redirect-uri: https://logs-deprecated.((system_domain))/login
     autoapprove: true
     secret: ((kibana-client-secret))
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Logs icon now on homepage! It will route to logs.<blah domain>
- Logs won't require people to approve the uaa client similar to stratos and old logs
- Logs old now says logs-deprecated

## security considerations
None