### PR TITLE
Pinning uaa to 77.20.2 to fix CVE while waiting for IDP fix from uaa team

### DIFF
--- a/bosh/opsfiles/pin-uaa.yml
+++ b/bosh/opsfiles/pin-uaa.yml
@@ -2,9 +2,9 @@
   path: /releases/name=uaa
   value:
     name: uaa
-    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=77.20.0
-    version: 77.20.0
-    sha1: b3237de30c42db8628498e71e1f40f4138215c7f
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=77.20.2
+    version: 77.20.2
+    sha1: 31f423a5d73f8e1b54576802c4f11d9e7beaaa30
 
 
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- Moving pined uaa to 77.20.2 to fix [CVE](https://www.cloudfoundry.org/blog/cve-2025-22216-uaa-missing-zone-validation/) while waiting for SAML IDP fix
-
-

## security considerations
This releases patches a known CVE
