### PR TITLE
Enable CNB in all envs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1315,8 +1315,8 @@ jobs:
             service_instance_sharing
             resource_matching
             route_sharing
-            diego_cnb
           DISABLED_FEATURE_FLAGS: |
+            diego_cnb
             user_org_creation
             hide_marketplace_from_unauthenticated_users
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -697,6 +697,7 @@ jobs:
             service_instance_sharing
             resource_matching
             route_sharing
+            diego_cnb
           DISABLED_FEATURE_FLAGS: |
             user_org_creation
             hide_marketplace_from_unauthenticated_users
@@ -1314,6 +1315,7 @@ jobs:
             service_instance_sharing
             resource_matching
             route_sharing
+            diego_cnb
           DISABLED_FEATURE_FLAGS: |
             user_org_creation
             hide_marketplace_from_unauthenticated_users


### PR DESCRIPTION
`diego_cnb` has been in dev for about 5 months, so time to roll it out more broadly. The [number of open issues for CNB](https://github.com/search?q=org%3Acloudfoundry+CNB&type=issues&s=created&o=desc) seems minimal, and the code seems pretty stable since Nov 2024. 

## Changes proposed in this pull request:
-
- Add `diego_cnb` to stage and prod
-

## security considerations
Safe. Enabling a core feature of CloudFoundry for our customers.
