### PR TITLE
deploy wazuh-agent in dev

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -35,6 +35,8 @@ jobs:
           - get: cg-s3-secureproxy-release
             trigger: true
           - get: general-task
+          - get: wazuh-agent
+            trigger: true
       - task: terraform-secrets
         image: general-task
         file: cf-manifests/ci/terraform-secrets.yml
@@ -53,7 +55,7 @@ jobs:
         params:
           ISO_SEG_NAMES: "" #((names_of_iso_segs_development))    # Value in credhub
       - put: cf-deployment-development
-        params: &deploy-params
+        params: 
           manifest: cf-deployment/cf-deployment.yml
           releases:
             - uaa-customized-release/*.tgz
@@ -117,9 +119,13 @@ jobs:
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/wazuh.yml
             - cf-manifests/bosh/opsfiles/pin-uaa.yml
+            - wazuh-agent/ops/add-wazuh-agent.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/development.yml
             - terraform-secrets/terraform.yml
+          vars:
+            environment: dev
+            wazuh_server_address: wazuh-server.service.cf.internal
 
       - task: enable-cf-features
         image: general-task
@@ -615,7 +621,12 @@ jobs:
           ISO_SEG_NAMES: "" #((names_of_iso_segs_staging))    # Value in credhub
       - put: cf-deployment-staging
         params:
-          <<: *deploy-params
+          manifest: cf-deployment/cf-deployment.yml
+          releases:
+            - uaa-customized-release/*.tgz
+            - cg-s3-secureproxy-release/*.tgz
+          stemcells:
+            - cf-stemcell-jammy/*.tgz
           ops_files:
             - router-main/router_main.yml
             - router-logstash/router_logstash.yml
@@ -1172,7 +1183,12 @@ jobs:
           ISO_SEG_NAMES: "" #((names_of_iso_segs_production))    # Value in credhub
       - put: cf-deployment-production
         params: &prod-deploy-params
-          <<: *deploy-params
+          manifest: cf-deployment/cf-deployment.yml
+          releases:
+            - uaa-customized-release/*.tgz
+            - cg-s3-secureproxy-release/*.tgz
+          stemcells:
+            - cf-stemcell-jammy/*.tgz
           dry_run: true
           ops_files:
             - router-main/router_main.yml
@@ -1746,6 +1762,21 @@ resources:
       repository: general-task
       aws_region: us-gov-west-1
       tag: latest
+
+  - name: wazuh-agent
+    type: git
+    source:
+      branch: main
+      commit_verification_keys: ((cloud-gov-pgp-keys))
+      git_config:
+      - name: "user.name"
+        value: "cg-ci-bot"
+      - name: "user.email"
+        value: "no-reply@cloud.gov"
+      paths: [ops/add-wazuh-agent.yml]
+      private_key: ((cg-ci-bot-sshkey.private_key))
+      uri: git@github.com:cloud-gov/wazuh-agent.git
+      username: cg-ci-bot
 
 resource_types:
   - name: registry-image


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds the wazuh agent in dev for testing.
When testing is complete, the agent should be installed via the runtime config and this should be reverted.

## security considerations

None
