### PR TITLE
Add CNB lifecycle to prod

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1315,8 +1315,8 @@ jobs:
             service_instance_sharing
             resource_matching
             route_sharing
+            diego_cnb            
           DISABLED_FEATURE_FLAGS: |
-            diego_cnb
             user_org_creation
             hide_marketplace_from_unauthenticated_users
 


### PR DESCRIPTION
The CNB job is now succeeding in staging (https://ci.fr.cloud.gov/teams/main/pipelines/test-hello-worlds/jobs/deploy-nodejs-cnb/builds/2) so this will enable `test-hello-worlds` to succeed in prod.

This is per our ADR at https://github.com/cloud-gov/internal-docs/blob/main/docs/ADRs/design-decisions/enable_cnbs.md

## Changes proposed in this pull request:
-
-
-

## security considerations

Safe. Already approved in referenced ADR.
