### PR TITLE
Updates scripts and non-terraform references to use v3 of the cf api

### DIFF
--- a/bosh/opsfiles/router-logstash.yml
+++ b/bosh/opsfiles/router-logstash.yml
@@ -48,6 +48,7 @@
             - hostname: api.((system_domain))
               exclude:
                 - ^/v2/info
+                - ^/v3/info
             - hostname: dashboard.((system_domain))
               exclude: []
           secret: ((tic-secret))

--- a/bosh/opsfiles/router-main.yml
+++ b/bosh/opsfiles/router-main.yml
@@ -48,6 +48,7 @@
             - hostname: api.((system_domain))
               exclude:
                 - ^/v2/info
+                - ^/v3/info
             - hostname: dashboard.((system_domain))
               exclude: []
           secret: ((tic-secret))

--- a/bosh/opsfiles/secureproxy.yml
+++ b/bosh/opsfiles/secureproxy.yml
@@ -40,7 +40,8 @@
           host_whitelist:
           - hostname: api.((system_domain))
             exclude:
-            - ^/v2/info
+              - ^/v2/info  
+              - ^/v3/info
           - hostname: dashboard.((system_domain))
             exclude: []
           secret: ((tic-secret))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -198,6 +198,7 @@ jobs:
           CF_API_URL: ((cf-api-url-development))
           CF_CLIENT_ID: ((cf-client-id-development))
           CF_CLIENT_SECRET: ((cf-client-secret-development))
+          TOKEN_ENDPOINT: ((token-endpoint-development))
           TF_VAR_remote_state_bucket: ((tf-state-bucket))
           TF_VAR_domain_name: dev.us-gov-west-1.aws-us-gov.cloud.gov
           TF_VAR_iaas_stack_name: development
@@ -885,6 +886,7 @@ jobs:
           CF_API_URL: ((cf-api-url-staging))
           CF_CLIENT_ID: ((cf-client-id-staging))
           CF_CLIENT_SECRET: ((cf-client-secret-staging))
+          TOKEN_ENDPOINT: ((token-endpoint-staging))
           TF_VAR_remote_state_bucket: ((tf-state-bucket))
           TF_VAR_domain_name: fr-stage.cloud.gov
           TF_VAR_iaas_stack_name: staging
@@ -1468,6 +1470,7 @@ jobs:
           CF_API_URL: ((cf-api-url-production))
           CF_CLIENT_ID: ((cf-client-id-production))
           CF_CLIENT_SECRET: ((cf-client-secret-production))
+          TOKEN_ENDPOINT: ((token-endpoint-production))
           TF_VAR_remote_state_bucket: ((tf-state-bucket))
           TF_VAR_domain_name: cloud.gov
           TF_VAR_iaas_stack_name: production

--- a/ci/test-headers/deploy-env.sh
+++ b/ci/test-headers/deploy-env.sh
@@ -18,11 +18,11 @@ cf api "${CF_API_URL}"
 wait_for_service_instance() {
   local service_name=$1
   local guid=$(cf service --guid $service_name)
-  local status=$(cf curl /v2/service_instances/${guid} | jq -r '.entity.last_operation.state')
+  local status=$(cf curl /v3/service_instances/${guid} | jq -r '.last_operation.state')
 
   while [ "$status" == "in progress" ]; do
     sleep 60
-    status=$(cf curl /v2/service_instances/${guid} | jq -r '.entity.last_operation.state')
+    status=$(cf curl /v3/service_instances/${guid} | jq -r '.last_operation.state')
   done
 }
 

--- a/ci/test-space-egress/deploy-env.sh
+++ b/ci/test-space-egress/deploy-env.sh
@@ -20,11 +20,11 @@ cf api "${CF_API_URL}"
 wait_for_service_instance() {
   local service_name=$1
   local guid=$(cf service --guid $service_name)
-  local status=$(cf curl /v2/service_instances/${guid} | jq -r '.entity.last_operation.state')
+  local status=$(cf curl /v3/service_instances/${guid} | jq -r '.last_operation.state')
 
   while [ "$status" == "in progress" ]; do
     sleep 60
-    status=$(cf curl /v2/service_instances/${guid} | jq -r '.entity.last_operation.state')
+    status=$(cf curl /v3/service_instances/${guid} | jq -r '.last_operation.state')
   done
 }
 

--- a/ci/tic-smoke-tests.sh
+++ b/ci/tic-smoke-tests.sh
@@ -18,7 +18,7 @@ gorouter_ip=$(
 
 @test "restricted user from allowed address can reach API" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v3/apps \
     -H "Host: ${API_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${SOURCE_ADDRESS_ALLOWED}" \
@@ -31,7 +31,7 @@ gorouter_ip=$(
 
 @test "restricted user from unallowed is blocked by secureproxy when requesting API" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v3/apps \
     -H "Host: ${API_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${SOURCE_ADDRESS_FORBIDDEN}" \
@@ -42,7 +42,7 @@ gorouter_ip=$(
 
 @test "x-client-ip is trusted when x-forwarded-for is a trusted proxy, allowing restricted user to access API from allowed address" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v3/apps \
     -H "Host: ${API_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
@@ -57,7 +57,7 @@ gorouter_ip=$(
 
 @test "x-client-ip is not trusted when x-forwarded-for is untrusted, disallowing restricted user from accessing API with allowed address in x-client-ip" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v3/apps \
     -H "Host: ${API_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${PROXY_ADDRESS_FORBIDDEN}" \
@@ -70,7 +70,7 @@ gorouter_ip=$(
 
 @test "x-client-ip is not trusted when x-tic-secret is invalid, disallowing restricted user from accessing API with allowed address in x-client-ip" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v3/apps \
     -H "Host: ${API_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
@@ -83,7 +83,7 @@ gorouter_ip=$(
 
 @test "x-client-ip is trusted when x-tic-secret and proxy address are trusted, disallowing restricted user from accessing API with disallowed address in x-client-ip" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v3/apps \
     -H "Host: ${API_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
@@ -96,7 +96,7 @@ gorouter_ip=$(
 
 @test "x-client-ip is not trusted when x-tic-secret is empty, disallowing restricted user from accessing API with allowed address in x-client-ip" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v3/apps \
     -H "Host: ${API_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
@@ -109,7 +109,7 @@ gorouter_ip=$(
 
 @test "unrestricted user can access API from forbidden address" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/v3/apps \
     -H "Host: ${API_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${unrestricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${SOURCE_ADDRESS_FORBIDDEN}" \
@@ -122,7 +122,7 @@ gorouter_ip=$(
 
 @test "restricted user can access the dashboard from an allowed address" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v3/apps \
     -H "Host: ${DASHBOARD_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${SOURCE_ADDRESS_ALLOWED}" \
@@ -136,7 +136,7 @@ gorouter_ip=$(
 
 @test "restricted user cannot access the dashboard from an unallowed address" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v3/apps \
     -H "Host: ${DASHBOARD_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${SOURCE_ADDRESS_FORBIDDEN}" \
@@ -147,7 +147,7 @@ gorouter_ip=$(
 
 @test "x-client-ip is trusted when x-forwarded-for is a trusted proxy, allowing restricted user to access dashboard from allowed address" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v3/apps \
     -H "Host: ${DASHBOARD_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
@@ -162,7 +162,7 @@ gorouter_ip=$(
 
 @test "x-client-ip is not trusted when x-forwarded-for is untrusted, disallowing restricted user from accessing dashboard with allowed address in x-client-ip" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v3/apps \
     -H "Host: ${DASHBOARD_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${PROXY_ADDRESS_FORBIDDEN}" \
@@ -175,7 +175,7 @@ gorouter_ip=$(
 
 @test "x-client-ip is not trusted when x-tic-secret is invalid, disallowing restricted user from accessing dashboard with allowed address in x-client-ip" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v3/apps \
     -H "Host: ${DASHBOARD_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
@@ -188,7 +188,7 @@ gorouter_ip=$(
 
 @test "x-client-ip is trusted when x-tic-secret and proxy address are trusted, disallowing restricted user from accessing dashboard with disallowed address in x-client-ip" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v3/apps \
     -H "Host: ${DASHBOARD_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
@@ -201,7 +201,7 @@ gorouter_ip=$(
 
 @test "x-client-ip is not trusted when x-tic-secret is empty, disallowing restricted user from accessing dashboard with allowed address in x-client-ip" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v3/apps \
     -H "Host: ${DASHBOARD_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${restricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${PROXY_ADDRESS_ALLOWED}" \
@@ -214,7 +214,7 @@ gorouter_ip=$(
 
 @test "unrestricted user can access the dashboard from unallowed address" {
   resp=$(curl -s -k \
-    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v2/apps \
+    ${TIC_PROTOCAL}://${gorouter_ip}:${GOROUTER_PORT:-443}/pp/v1/proxy/v3/apps \
     -H "Host: ${DASHBOARD_HOSTNAME}" \
     -H "Authorization: $(echo '{}' | base64).$(echo ${unrestricted_payload} | base64).$(echo '{}' | base64)" \
     -H "X-Forwarded-For: ${SOURCE_ADDRESS_FORBIDDEN}" \

--- a/terraform/terraform-apply.sh
+++ b/terraform/terraform-apply.sh
@@ -2,12 +2,8 @@
 
 set -eu
 
-# Use client credentials in CF_CLIENT_ID and CF_CLIENT_SECRET to fetch a token
-API_RESPONSE=$(curl -s $CF_API_URL/v2/info)
-TOKEN_ENDPOINT=$(echo ${API_RESPONSE} | jq -r '.token_endpoint // empty')
-
 if [ -z "${TOKEN_ENDPOINT}" ]; then
-  echo "API didn't return a token endpoint: ${API_RESPONSE}"
+  echo "TOKEN_ENDPOINT not set"
   exit 99;
 fi
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the non-terraform usage of the v3 api. The terraform updates require multiple steps and will be made in a different PR.

This update requires additional values to be inserted into credhub. The information output by the /v*/info endpoint has changed and no longer contains the Token Endpoint for UAA. A credential file is ready to be imported but omitted from this public repo.

_Note - the default recommended CLI version will be updated in a separate issue: https://github.com/cloud-gov/private/issues/2428_

## security considerations

None
