### PR TITLE
add CF user for opensearch e2e test setup

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -203,7 +203,7 @@ jobs:
           TF_VAR_domain_name: dev.us-gov-west-1.aws-us-gov.cloud.gov
           TF_VAR_iaas_stack_name: development
           TF_VAR_tooling_stack_name: tooling
-          TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
+          TF_VAR_opensearch_e2e_test_setup_user_password: ((development-opensearch-e2e-test-setup-user-password))
       - put: slack
         params:
           text_file: terraform-state/message.txt
@@ -891,6 +891,7 @@ jobs:
           TF_VAR_domain_name: fr-stage.cloud.gov
           TF_VAR_iaas_stack_name: staging
           TF_VAR_tooling_stack_name: tooling
+          TF_VAR_opensearch_e2e_test_setup_user_password: ((staging-opensearch-e2e-test-setup-user-password))
       - put: slack
         params:
           text_file: terraform-state/message.txt
@@ -1317,7 +1318,7 @@ jobs:
             service_instance_sharing
             resource_matching
             route_sharing
-            diego_cnb            
+            diego_cnb
           DISABLED_FEATURE_FLAGS: |
             user_org_creation
             hide_marketplace_from_unauthenticated_users
@@ -1475,6 +1476,7 @@ jobs:
           TF_VAR_domain_name: cloud.gov
           TF_VAR_iaas_stack_name: production
           TF_VAR_tooling_stack_name: tooling
+          TF_VAR_opensearch_e2e_test_setup_user_password: ((production-opensearch-e2e-test-setup-user-password))
       - put: slack
         params:
           text_file: terraform-state/message.txt

--- a/terraform/stacks/cf/users.tf
+++ b/terraform/stacks/cf/users.tf
@@ -1,0 +1,6 @@
+resource "cloudfoundry_user" "opensearch_e2e_test_setup_user" {
+  name     = "opensearch-e2e-test-setup-user"
+  password = var.opensearch_e2e_test_setup_user_password
+
+  groups = ["cloud_controller.admin", "scim.read", "scim.write"]
+}

--- a/terraform/stacks/cf/variables.tf
+++ b/terraform/stacks/cf/variables.tf
@@ -9,3 +9,8 @@ variable "iaas_stack_name" {
 
 variable "domain_name" {
 }
+
+variable "opensearch_e2e_test_setup_user_password" {
+  type        = string
+  description = "Password for OpenSearch E2E test setup user"
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- add CF user for opensearch e2e test setup

## security considerations

The test user is a global administrator, but the credentials will be kept safely in Credhub
