### PR TITLE
Adding CF URL for service_guid call

### DIFF
--- a/ci/uaa-client-audit.sh
+++ b/ci/uaa-client-audit.sh
@@ -50,7 +50,7 @@ uaapaginate() {
 # Get known clients from broker
 service_label="cloud-gov-identity-provider"
 
-service_guid=$(cfcurl "/v3/service_offerings?names=${service_label}" | jq -r '.resources[0].guid')
+service_guid=$(cfcurl "${CF_API_URL}/v3/service_offerings?names=${service_label}" | jq -r '.resources[0].guid')
 service_plan_guids=$(paginate "/v3/service_plans?service_offering_guids=${service_guid}" ".resources[].guid")
 
 service_plan_list=$(echo "${service_plan_guids}" | paste -sd "," -)


### PR DESCRIPTION
## Changes proposed in this pull request:
- Hunted down the `curl: (3) URL using bad/illegal format or missing URL` error to this line.  When switching from `cf curl` to the `cfcurl()` function, need to pass in the full url, including the the api.
- Causes the `uaa-client-audit-production` job to populate prometheus with false positive uaa client alerts
- Part of maintenance https://github.com/cloud-gov/product/issues/2836
-

## security considerations
Filters out known provisioned clients like it did a couple days ago.  No changes to security boundaries or charges for extra toppings.
