### PR TITLE
chore: update minimum recommended CF version

### DIFF
--- a/bosh/opsfiles/api-defaults.yml
+++ b/bosh/opsfiles/api-defaults.yml
@@ -12,7 +12,7 @@
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/min_recommended_cli_version?
-  value: 7.7.1
+  value: 8.9.0
 
 
 - type: replace


### PR DESCRIPTION
My thinking for 8.8.0 was that users should be able to update their CF CLI at least once per quarter, so I picked the last release before January. I also skimmed the release notes before and after to see if anything seemed to be a must-have or must-avoid and didn't find anything worth noting

## Changes proposed in this pull request:
- Update minimum recommended CF version


## security considerations
No direct implications here, but this nudge should ease the transition to CAPI v3, which will mean we can stay on top of patches once it's rolled out.