### PR TITLE
add opensearch-ci-cf-read-only UAA client and secret

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -156,6 +156,21 @@
     type: password
 
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/opensearch-ci-cf-read-only?
+  value:
+    override: true
+    authorized-grant-types: client_credentials
+    scope: cloud_controller.read,openid,scim.read
+    authorities: scim.read
+    secret: ((opensearch-ci-cf-read-only-secret))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: opensearch-ci-cf-read-only-secret
+    type: password
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/opensearch_dashboards_proxy?
   value:
     override: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- add opensearch-ci-cf-read-only UAA client and secret for reading in CF audit events from a CI job

## security considerations

None. The code changes are not sensitive. We are intentionally creating this read-only UAA client to follow the principle of least privilege rather than using a UAA client with extra permissions
