### PR TITLE
update opensearch-ci-cf-read-only UAA client

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -160,7 +160,6 @@
   value:
     override: true
     authorized-grant-types: client_credentials
-    scope: cloud_controller.global_auditor,openid,scim.read
     authorities: scim.read,cloud_controller.global_auditor
     secret: ((opensearch-ci-cf-read-only-secret))
 

--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -160,8 +160,8 @@
   value:
     override: true
     authorized-grant-types: client_credentials
-    scope: cloud_controller.read,openid,scim.read
-    authorities: scim.read
+    scope: cloud_controller.global_auditor,openid,scim.read
+    authorities: scim.read,cloud_controller.global_auditor
     secret: ((opensearch-ci-cf-read-only-secret))
 
 - type: replace


### PR DESCRIPTION

## Changes proposed in this pull request:

- update opensearch-ci-cf-read-only UAA client to have cloud_controller.global_auditor permissions which is necessary for pulling audit events


## security considerations

global_auditor scope is still read-ony, so these permissions are least privilege for how the client is used. See https://docs.cloudfoundry.org/concepts/roles.html
