### PR TITLE
Adding sandbox-bot-user to CF UAA

### DIFF
--- a/bosh/opsfiles/users.yml
+++ b/bosh/opsfiles/users.yml
@@ -26,3 +26,17 @@
   value:
     name: autoscaler-password
     type: password
+
+# Sandbox Bot user
+# Note: this user is used by the acceptance tests, the sandbox-bot client is used inside the app and doesn't need the higher level of permissions
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/scim/users/-
+  value:
+    name: sandbox-bot-user
+    password: ((sandbox-bot-password))
+    groups: [openid, cloud_controller.admin, scim.read, scim.write]
+- type: replace
+  path: /variables/-
+  value:
+    name: sandbox-bot-password
+    type: password


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds the `sandbox-bot-user` to be used by the (new) sandbox-bot staging acceptance tests, admin access needed for creating/deleting orgs, users and quotas created during the tests.
- The existing `sandbox-bot` client was left alone, those credentials are used to push the CF app in the pipeline and do not need the extra privileges.
- Part of https://github.com/cloud-gov/sandbox-bot/issues/77

## security considerations
Adds a new user similar to `autoscaler` for the sole purpose of running the staging acceptance tests for sandbox-bot
