### PR TITLE
Upgrade the cf provider from cloudfoundry-community to cloudfoundry (V3)

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -160,8 +160,7 @@
   value:
     override: true
     authorized-grant-types: client_credentials
-    scope: cloud_controller.read,openid,scim.read
-    authorities: scim.read
+    authorities: scim.read,cloud_controller.global_auditor
     secret: ((opensearch-ci-cf-read-only-secret))
 
 - type: replace

--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -156,6 +156,21 @@
     type: password
 
 - type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/opensearch-ci-cf-read-only?
+  value:
+    override: true
+    authorized-grant-types: client_credentials
+    scope: cloud_controller.read,openid,scim.read
+    authorities: scim.read
+    secret: ((opensearch-ci-cf-read-only-secret))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: opensearch-ci-cf-read-only-secret
+    type: password
+
+- type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/opensearch_dashboards_proxy?
   value:
     override: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -203,7 +203,7 @@ jobs:
           TF_VAR_domain_name: dev.us-gov-west-1.aws-us-gov.cloud.gov
           TF_VAR_iaas_stack_name: development
           TF_VAR_tooling_stack_name: tooling
-          TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
+          TF_VAR_opensearch_e2e_test_setup_user_password: ((development-opensearch-e2e-test-setup-user-password))
       - put: slack
         params:
           text_file: terraform-state/message.txt
@@ -891,6 +891,7 @@ jobs:
           TF_VAR_domain_name: fr-stage.cloud.gov
           TF_VAR_iaas_stack_name: staging
           TF_VAR_tooling_stack_name: tooling
+          TF_VAR_opensearch_e2e_test_setup_user_password: ((staging-opensearch-e2e-test-setup-user-password))
       - put: slack
         params:
           text_file: terraform-state/message.txt
@@ -1317,7 +1318,7 @@ jobs:
             service_instance_sharing
             resource_matching
             route_sharing
-            diego_cnb            
+            diego_cnb
           DISABLED_FEATURE_FLAGS: |
             user_org_creation
             hide_marketplace_from_unauthenticated_users
@@ -1475,6 +1476,7 @@ jobs:
           TF_VAR_domain_name: cloud.gov
           TF_VAR_iaas_stack_name: production
           TF_VAR_tooling_stack_name: tooling
+          TF_VAR_opensearch_e2e_test_setup_user_password: ((production-opensearch-e2e-test-setup-user-password))
       - put: slack
         params:
           text_file: terraform-state/message.txt

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -203,7 +203,6 @@ jobs:
           TF_VAR_domain_name: dev.us-gov-west-1.aws-us-gov.cloud.gov
           TF_VAR_iaas_stack_name: development
           TF_VAR_tooling_stack_name: tooling
-          TF_VAR_opensearch_e2e_test_setup_user_password: ((development-opensearch-e2e-test-setup-user-password))
       - put: slack
         params:
           text_file: terraform-state/message.txt
@@ -891,7 +890,6 @@ jobs:
           TF_VAR_domain_name: fr-stage.cloud.gov
           TF_VAR_iaas_stack_name: staging
           TF_VAR_tooling_stack_name: tooling
-          TF_VAR_opensearch_e2e_test_setup_user_password: ((staging-opensearch-e2e-test-setup-user-password))
       - put: slack
         params:
           text_file: terraform-state/message.txt
@@ -1476,7 +1474,6 @@ jobs:
           TF_VAR_domain_name: cloud.gov
           TF_VAR_iaas_stack_name: production
           TF_VAR_tooling_stack_name: tooling
-          TF_VAR_opensearch_e2e_test_setup_user_password: ((production-opensearch-e2e-test-setup-user-password))
       - put: slack
         params:
           text_file: terraform-state/message.txt

--- a/ci/test-space-egress/requirements.txt
+++ b/ci/test-space-egress/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==2.0.4
 click==8.0.1
 fastapi==0.115.4
 furl==2.1.3
-h11==0.12.0
+h11==0.16.0
 idna==3.7
 mypy-extensions==0.4.3
 orderedmultidict==1.0.1

--- a/terraform/stacks/cf/users.tf
+++ b/terraform/stacks/cf/users.tf
@@ -1,6 +1,0 @@
-resource "cloudfoundry_user" "opensearch_e2e_test_setup_user" {
-  name     = "opensearch-e2e-test-setup-user"
-  password = var.opensearch_e2e_test_setup_user_password
-
-  groups = ["cloud_controller.admin", "scim.read", "scim.write"]
-}

--- a/terraform/stacks/cf/users.tf
+++ b/terraform/stacks/cf/users.tf
@@ -1,0 +1,6 @@
+resource "cloudfoundry_user" "opensearch_e2e_test_setup_user" {
+  name     = "opensearch-e2e-test-setup-user"
+  password = var.opensearch_e2e_test_setup_user_password
+
+  groups = ["cloud_controller.admin", "scim.read", "scim.write"]
+}

--- a/terraform/stacks/cf/variables.tf
+++ b/terraform/stacks/cf/variables.tf
@@ -9,8 +9,3 @@ variable "iaas_stack_name" {
 
 variable "domain_name" {
 }
-
-variable "opensearch_e2e_test_setup_user_password" {
-  type        = string
-  description = "Password for OpenSearch E2E test setup user"
-}

--- a/terraform/stacks/cf/variables.tf
+++ b/terraform/stacks/cf/variables.tf
@@ -9,3 +9,8 @@ variable "iaas_stack_name" {
 
 variable "domain_name" {
 }
+
+variable "opensearch_e2e_test_setup_user_password" {
+  type        = string
+  description = "Password for OpenSearch E2E test setup user"
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

This PR upgrades the terraform provider from the cloudfoundry-community version, which leverages v2 of the CF API, with the cloudfoundry version, that leverages V3 of the CF API. 

This is a PR of the final state of the `.tf` files. This branch contains interim commits used to remove the old resources from the state file then import the resources under the new provider. After merging the PR, the branch will be manually restored and used to upgrade staging and production.

The staging upgrade may require additional changes as the `test_cdn` is not implemented in dev and therefore could not be tested. https://github.com/cloud-gov/deploy-cf/blob/b0c3e4f7a7df655755ca35ba510d401ed9d83701/terraform/stacks/cf/apps.tf#L2

Additionally:

- The upgrade process is not implemented as a concourse job or task. The provider versions do not have resource parity. The upgrade is achieved via a temporary script with a manual statefile intervention to deal with a non-importable resource. The script will be deleted after the upgrades are complete. https://github.com/cloud-gov/deploy-cf/blob/cf-provider-v3/terraform/scripts/update-provider.sh

- Each environment will be updated individually. Production will be scheduled with the maintenance engineer. 

- This update should not result in any changes to the infrastructure (only terraform state).

- The terraform plan and apply jobs in concourse are paused for each environment and will be unpaused when the state has been updated with no changes detected. 

## security considerations

None
