### PR TITLE
Upgrade the cf provider from cloudfoundry-community to cloudfoundry (V3)

### DIFF
--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -1,24 +1,21 @@
 locals {
-  domain_name = var.iaas_stack_name == "staging" ? "fr-stage.cloud.gov" : "fr.cloud.gov"
-  clone_dir = "${path.module}/${var.git_clone_dir}"
+  domain_name         = var.iaas_stack_name == "staging" ? "fr-stage.cloud.gov" : "fr.cloud.gov"
+  clone_dir           = "${path.module}/${var.git_clone_dir}"
   zip_output_filepath = "${path.module}/${var.zip_output_filename}"
 }
 
 data "cloudfoundry_domain" "fr_domain" {
   name = local.domain_name
-  provider = cloudfoundryv3
 }
 
 data "cloudfoundry_service_plan" "external_domain" {
   service_offering_name = "external-domain"
-  name = "domain-with-cdn-dedicated-waf"
-  provider = cloudfoundryv3
+  name                  = "domain-with-cdn-dedicated-waf"
 }
 
 data "cloudfoundry_space" "hello_worlds" {
   name = var.space_name
   org  = var.organization_id
-  provider = cloudfoundryv3
 }
 
 resource "null_resource" "git_clone" {
@@ -32,7 +29,7 @@ resource "null_resource" "git_clone" {
 }
 
 data "archive_file" "test_cdn_app_src" {
-  depends_on  = [null_resource.git_clone]
+  depends_on = [null_resource.git_clone]
 
   output_path = local.zip_output_filepath
   source_dir  = "${local.clone_dir}/${var.source_code_path}"
@@ -40,10 +37,9 @@ data "archive_file" "test_cdn_app_src" {
 }
 
 resource "cloudfoundry_route" "test_cdn_route" {
-  domain   = data.cloudfoundry_domain.fr_domain.id
-  space    = data.cloudfoundry_space.hello_worlds.id
-  host = "test-cdn"
-  provider = cloudfoundryv3
+  domain = data.cloudfoundry_domain.fr_domain.id
+  space  = data.cloudfoundry_space.hello_worlds.id
+  host   = "test-cdn"
 }
 
 # DNS records:
@@ -51,23 +47,21 @@ resource "cloudfoundry_route" "test_cdn_route" {
 # https://github.com/cloud-gov/cg-provision/blob/417000c786a101988c3edd965f7c78f66ad334fe/terraform/stacks/dns/production.tf#L12-L17
 resource "cloudfoundry_service_instance" "test_cdn_instance" {
   name         = "test-cdn-service"
-  type = "managed"
+  type         = "managed"
   space        = data.cloudfoundry_space.hello_worlds.id
   service_plan = data.cloudfoundry_service_plan.external_domain.id
-  parameters  = "{\"domains\": \"test-cdn.${local.domain_name}\"}"
-  provider = cloudfoundryv3
+  parameters   = "{\"domains\": \"test-cdn.${local.domain_name}\"}"
 }
 
 resource "cloudfoundry_app" "test-cdn" {
   name             = "test-cdn"
-  buildpacks        = ["staticfile_buildpack"]
-  org_name = var.organization_id  
-  space_name            = data.cloudfoundry_space.hello_worlds.id
+  buildpacks       = ["staticfile_buildpack"]
+  org_name         = var.organization_id
+  space_name       = data.cloudfoundry_space.hello_worlds.id
   path             = local.zip_output_filepath
   source_code_hash = data.archive_file.test_cdn_app_src.output_sha256
 
   routes = [{
     route = cloudfoundry_route.test_cdn_route.id
   }]
-  provider = cloudfoundryv3
 }

--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -9,8 +9,9 @@ data "cloudfoundry_domain" "fr_domain" {
   provider = cloudfoundryv3
 }
 
-data "cloudfoundry_service" "external_domain" {
-  name = "external-domain"
+data "cloudfoundry_service_plan" "external_domain" {
+  service_offering_name = "external-domain"
+  name = "domain-with-cdn-dedicated-waf"
   provider = cloudfoundryv3
 }
 
@@ -50,8 +51,9 @@ resource "cloudfoundry_route" "test_cdn_route" {
 # https://github.com/cloud-gov/cg-provision/blob/417000c786a101988c3edd965f7c78f66ad334fe/terraform/stacks/dns/production.tf#L12-L17
 resource "cloudfoundry_service_instance" "test_cdn_instance" {
   name         = "test-cdn-service"
+  type = "managed"
   space        = data.cloudfoundry_space.hello_worlds.id
-  service_plan = data.cloudfoundry_service.external_domain.service_plans["domain-with-cdn-dedicated-waf"]
+  service_plan = data.cloudfoundry_service_plan.external_domain.id
   parameters  = "{\"domains\": \"test-cdn.${local.domain_name}\"}"
   provider = cloudfoundryv3
 }
@@ -64,8 +66,8 @@ resource "cloudfoundry_app" "test-cdn" {
   path             = local.zip_output_filepath
   source_code_hash = data.archive_file.test_cdn_app_src.output_sha256
 
-  routes {
+  routes = [{
     route = cloudfoundry_route.test_cdn_route.id
-  }
+  }]
   provider = cloudfoundryv3
 }

--- a/terraform/modules/test_cdn/versions.tf
+++ b/terraform/modules/test_cdn/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "cloudfoundry-community/cloudfoundry"
       version = "0.53.0"
     }
+    cloudfoundryv3 = {
+      source  = "cloudfoundry/cloudfoundry"
+      version = "1.4.0"
+    }
   }
 }

--- a/terraform/modules/test_cdn/versions.tf
+++ b/terraform/modules/test_cdn/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_version = "< 2.0.0"
   required_providers {
-    cloudfoundry = {
-      source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.53.0"
-    }
     cloudfoundryv3 = {
       source  = "cloudfoundry/cloudfoundry"
       version = "< 2.0"

--- a/terraform/modules/test_cdn/versions.tf
+++ b/terraform/modules/test_cdn/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = "< 2.0.0"
   required_providers {
-    cloudfoundryv3 = {
+    cloudfoundry = {
       source  = "cloudfoundry/cloudfoundry"
       version = "< 2.0"
     }

--- a/terraform/modules/test_cdn/versions.tf
+++ b/terraform/modules/test_cdn/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     cloudfoundryv3 = {
       source  = "cloudfoundry/cloudfoundry"
-      version = "1.4.0"
+      version = "< 2.0"
     }
   }
 }

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -36,7 +36,7 @@ pushd $this_directory/../stacks/cf
     read user_input
 
     # Dual provider with v3 tf
-    git checkout 5e53d6637c3495bc08d3f606466ab2111fd1d77a
+    git checkout 0641608d94c8b315c9ad81eef92e56c5aacd9155
 
     for address in $addresses; do
         if [[ "$address" =~ ^data* ]]; then

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -1,0 +1,69 @@
+set -e
+
+if [ -z "$1" ]; then
+    echo "Specify env: $0 dev | stage | prod"
+    exit
+fi
+
+env=$1
+
+this_directory=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+pushd $this_directory/../stacks/cf
+
+    # # Add provider
+    git checkout d7c0aaefe5db36a530d2190713e5fb30c99fd969
+
+    terraform show -json > existing.json
+
+    addresses=$(cat existing.json | jq -r '.values.root_module.resources[] | select(.provider_name == "registry.terraform.io/cloudfoundry-community/cloudfoundry") | .address')
+    
+    for address in $addresses; do
+        existing_type=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.resources[] | select(.address==$address) | .type')
+        case $existing_type in
+            cloudfoundry_isolation_segment_entitlement)
+                echo "Skipping delete of cloudfoundry_isolation_segment_entitlement.${name} as state will be modified directly (new resource is not importable)."
+                continue
+                ;;
+            *)
+                echo "Removing state for $address"
+                terraform state rm $address
+                ;;
+            esac
+    done
+
+    echo -n "Download, modify, and upload the tfstate file for the entitlement resource. Then hit any key to continue."
+    read user_input
+
+    # Dual provider with v3 tf
+    git checkout a8462c6e15ba095b768cd65c57c8c48330985258
+
+    for address in $addresses; do
+        if [[ "$address" =~ ^data* ]]; then
+            echo "Skipping import of data object: $address"
+        else
+            existing_type=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.resources[] | select(.address==$address) | .type')
+            tf_id=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.resources[] | select(.address==$address) | .values.id')
+            name=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.resources[] | select(.address==$address) | .name')
+            case $existing_type in
+                cloudfoundry_asg)
+                    new_type="cloudfoundry_security_group"
+                    ;;
+                cloudfoundry_default_asg)
+                    echo "Skipping import of cloudfoundry_default_asg.${name} as it no longer exists in the new provider."
+                    continue
+                    ;;
+                cloudfoundry_isolation_segment_entitlement)
+                    echo "Skipping import of cloudfoundry_isolation_segment_entitlement.${name} as it is not currently importable."
+                    continue
+                    ;;
+                *)
+                    new_type="$existing_type"
+                    ;;
+            esac
+            echo "Importing "${new_type}.${name}" $tf_id"
+            terraform import -var-file=${env}-vars.tfvars "${new_type}.${name}" "$tf_id"
+        fi
+    done
+    #rm existing.json
+popd

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -32,7 +32,7 @@ pushd $this_directory/../stacks/cf
             esac
     done
 
-    echo -n "Download, modify, and upload the tfstate file for the entitlement resource. Then hit any key to continue."
+    echo -n "Download, modify, and upload the tfstate file for the entitlement resource (remove the id and update the provider). Then hit any key to continue."
     read user_input
 
     # Dual provider with v3 tf

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -36,7 +36,7 @@ pushd $this_directory/../stacks/cf
     read user_input
 
     # Dual provider with v3 tf
-    git checkout a8462c6e15ba095b768cd65c57c8c48330985258
+    git checkout 5e53d6637c3495bc08d3f606466ab2111fd1d77a
 
     for address in $addresses; do
         if [[ "$address" =~ ^data* ]]; then

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -80,6 +80,9 @@ popd
 pushd $this_directory/..
     echo "Removing old provider"
     git checkout cf-provider-v3
+popd    
+
+pushd $this_directory/../stacks/cf
     if [[ "$env" == "dev" ]]; then
         backend_config_key="cf-development/terraform.tfstate"
     elif [[ "$env" == "stage" ]]; then
@@ -97,9 +100,6 @@ pushd $this_directory/..
         "-backend-config=region=us-gov-west-1"
     )
     terraform init -upgrade "${init_args[@]}"
-popd    
-
-pushd $this_directory/../stacks/cf
     changes=$(terraform plan -json -var-file=dev.tfvars -out output | tail -n 1 | jq -r '.changes')
     to_add=$(echo "$changes" | jq -r '.add')
     to_change=$(echo "$changes" | jq -r '.change')

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -74,22 +74,25 @@ pushd $this_directory/../stacks/cf
         echo "CHANGES DETECTED. Exiting."
         terraform show output
         exit 1
+    fi
+popd
+
+pushd $this_directory/..
+    echo "Removing old provider"
+    git checkout cf-provider-v3
+popd
+
+pushd $this_directory/../stacks/cf
+    changes=$(terraform plan -json -var-file=dev.tfvars -out output | tail -n 1 | jq -r '.changes')
+    to_add=$(echo "$changes" | jq -r '.add')
+    to_change=$(echo "$changes" | jq -r '.change')
+    to_import=$(echo "$changes" | jq -r '.import')
+    to_remove=$(echo "$changes" | jq -r '.remove')
+    if [ $to_add -gt 0 ] || [ $to_change -gt 0 ] || [ $to_import -gt 0 ] || [ $to_remove -gt 0 ]; then
+        echo "CHANGES DETECTED. Something is still wrong. Exiting."
+        terraform show output
+        exit 1
     else 
-        echo "No changes detected. Continuing..."
-        echo "Removing old provider"
-        git checkout 430db263a0abc3f3217d3f9ae0c565c399e5833e
-        changes=$(terraform plan -json -var-file=dev.tfvars -out output | tail -n 1 | jq -r '.changes')
-        to_add=$(echo "$changes" | jq -r '.add')
-        to_change=$(echo "$changes" | jq -r '.change')
-        to_import=$(echo "$changes" | jq -r '.import')
-        to_remove=$(echo "$changes" | jq -r '.remove')
-        if [ $to_add -gt 0 ] || [ $to_change -gt 0 ] || [ $to_import -gt 0 ] || [ $to_remove -gt 0 ]; then
-            echo "CHANGES DETECTED. Something is still wrong. Exiting."
-            terraform show output
-            exit 1
-        else 
-            echo "Old provider removed. Good work."
-        fi
-    fi 
-    
+        echo "Old provider removed. Good work."
+    fi
 popd

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -36,7 +36,7 @@ pushd $this_directory/../stacks/cf
     read user_input
 
     # Dual provider with v3 tf
-    git checkout 0641608d94c8b315c9ad81eef92e56c5aacd9155
+    git checkout 28732f5381e1eda685048fdcab8cfb839418e1a2
 
     for address in $addresses; do
         if [[ "$address" =~ ^data* ]]; then

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -62,7 +62,7 @@ pushd $this_directory/../stacks/cf
                     ;;
             esac
             echo "Importing "${new_type}.${name}" $tf_id"
-            terraform import -var-file=${env}-vars.tfvars "${new_type}.${name}" "$tf_id"
+            terraform import -var-file=${env}.tfvars "${new_type}.${name}" "$tf_id"
         fi
     done
     #rm existing.json

--- a/terraform/stacks/cf/asg.tf
+++ b/terraform/stacks/cf/asg.tf
@@ -1,27 +1,32 @@
-#renamed resource
 resource "cloudfoundry_security_group" "public_networks" {
   name = "public_networks"
   rules = [
     {
       protocol    = "all"
       destination = "0.0.0.0-9.255.255.255"
+      log = false
     },
     {
       protocol    = "all"
       destination = "11.0.0.0-169.253.255.255"
+      log = false
     },
     {
       protocol    = "all"
       destination = "169.255.0.0-172.15.255.255"
+      log = false
     },
     {
       protocol    = "all"
       destination = "172.32.0.0-192.167.255.255"
+      log = false
     },
     {
       protocol    = "all"
       destination = "192.169.0.0-255.255.255.255"
-  }, ]
+      log = false
+    }, 
+  ]
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
   provider = cloudfoundryv3
@@ -29,7 +34,6 @@ resource "cloudfoundry_security_group" "public_networks" {
 
 
 # New public_networks asg to apply to spaces individually, not globally.
-#renamed resource
 resource "cloudfoundry_security_group" "public_networks_egress" {
   name = "public_networks_egress"
 
@@ -40,40 +44,46 @@ resource "cloudfoundry_security_group" "public_networks_egress" {
     {
       protocol    = "all"
       destination = "0.0.0.0-9.255.255.255"
+      log = false
     },
     {
       protocol    = "all"
       destination = "11.0.0.0-169.253.255.255"
+      log = false
     },
     {
       protocol    = "all"
       destination = "169.255.0.0-172.15.255.255"
+      log = false
     },
     {
       protocol    = "all"
       destination = "172.32.0.0-192.167.255.255"
+      log = false
     },
     {
       protocol    = "all"
       destination = "192.169.0.0-255.255.255.255"
+      log = false
     },
     {
       description = "Rule for private endpoint to s3 in region"
       protocol    = "tcp"
       destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if1_ip
       ports       = "443"
+      log = false
     },
     {
       description = "Rule for private endpoint to s3 in region"
       protocol    = "tcp"
       destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if2_ip
       ports       = "443"
+      log = false
     },
   ]
   provider = cloudfoundryv3
 }
 
-#renamed resource
 resource "cloudfoundry_security_group" "dns" {
   name                     = "dns"
   globally_enabled_running = true
@@ -84,11 +94,13 @@ resource "cloudfoundry_security_group" "dns" {
       protocol    = "tcp"
       ports       = "53"
       destination = "0.0.0.0/0"
+      log = false
     },
     {
       protocol    = "udp"
       ports       = "53"
       destination = "0.0.0.0/0"
+      log = false
     },
   ]
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
@@ -97,8 +109,6 @@ resource "cloudfoundry_security_group" "dns" {
 }
 
 # New dns asg to apply to spaces individually, not globally.
-
-#renamed resource
 resource "cloudfoundry_security_group" "dns_egress" {
   name = "dns_egress"
 
@@ -107,45 +117,49 @@ resource "cloudfoundry_security_group" "dns_egress" {
       protocol    = "tcp"
       ports       = "53"
       destination = "0.0.0.0/0"
+      log = false
     },
     {
       protocol    = "udp"
       ports       = "53"
       destination = "0.0.0.0/0"
+      log = false
     },
   ]
   provider = cloudfoundryv3
 }
 
-#renamed resource
-resource "cloudfoundry_security_group" "trusted_local_networks" {
-  name = "trusted_local_networks"
 
-  # RDS access for postgres, mysql, mssql, oracle
-  rules = [
+
+locals {
+  trusted_local_networks_rules_1 = [
     {
       protocol    = "tcp"
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az1
       ports       = "5432,3306,1433,1521"
+      log = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az2
       ports       = "5432,3306,1433,1521"
+      log = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az3
       ports       = "5432,3306,1433,1521"
+      log = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az4
       ports       = "5432,3306,1433,1521"
+      log = false
     },
     # Elasticache access
     {
@@ -153,12 +167,14 @@ resource "cloudfoundry_security_group" "trusted_local_networks" {
       description = "Allow access to Elasticache"
       destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az1
       ports       = "6379"
+      log = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to Elasticache"
       destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az2
       ports       = "6379"
+      log = false
     },
     # Elastisearch access
     {
@@ -166,119 +182,155 @@ resource "cloudfoundry_security_group" "trusted_local_networks" {
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az1
       ports       = "443"
+      log = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
       ports       = "443"
+      log = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az3
       ports       = "443"
+      log = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az4
       ports       = "443"
-    },
-    # S3 Gateway access
-    {
-      for_each    = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs
-      protocol    = "tcp"
-      description = "Allow access to AWS S3 Gateway"
-      destination = each.value
-      ports       = "443"
+      log = false
     },
   ]
+
+  trusted_local_networks_rules_2 = [
+    for cidr in data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs :
+    { 
+      protocol    = "tcp"
+      description = "Allow access to AWS S3 Gateway"
+      destination = cidr
+      ports       = "443"
+      log = false
+    }
+  ]
+
+  trusted_local_networks_rules = concat(local.trusted_local_networks_rules_1, local.trusted_local_networks_rules_2)
+}
+
+resource "cloudfoundry_security_group" "trusted_local_networks" {
+  name = "trusted_local_networks"
+
+  # RDS access for postgres, mysql, mssql, oracle
+  rules = local.trusted_local_networks_rules
+
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.email.id]
   provider = cloudfoundryv3
 }
 
-# New trusted networks asg to apply to spaces individually, not globally.
+locals {
+  trusted_local_networks_egress_rules_1 = [
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az1
+      ports       = "5432,3306,1433,1521"
+      log = false
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az2
+      ports       = "5432,3306,1433,1521"
+      log = false
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az3
+      ports       = "5432,3306,1433,1521"
+      log = false
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az4
+      ports       = "5432,3306,1433,1521"
+      log = false
+    },
+    # Elasticache access
+    {
+      protocol    = "tcp"
+      description = "Allow access to Elasticache"
+      destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az1
+      ports       = "6379"
+      log = false
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to Elasticache"
+      destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az2
+      ports       = "6379"
+      log = false
+    },
+    # Elastisearch access
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az1
+      ports       = "443"
+      log = false
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
+      ports       = "443"
+      log = false
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az3
+      ports       = "443"
+      log = false
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az4
+      ports       = "443"
+      log = false
+    },
+  ]
 
+  trusted_local_networks_egress_rules_2 = [
+    for cidr in data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs :
+    { 
+      protocol    = "tcp"
+      description = "Allow access to AWS S3 Gateway"
+      destination = cidr
+      ports       = "443"
+      log = false
+    }
+  ]
+
+  trusted_local_networks_egress_rules = concat(local.trusted_local_networks_egress_rules_1, local.trusted_local_networks_egress_rules_2)
+}
+
+# New trusted networks asg to apply to spaces individually, not globally.
 resource "cloudfoundry_security_group" "trusted_local_networks_egress" {
   name = "trusted_local_networks_egress"
 
   globally_enabled_staging = true
 
   # RDS access for postgres, mysql, mssql, oracle
-  rules = [
-    {
-      protocol    = "tcp"
-      description = "Allow access to RDS"
-      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az1
-      ports       = "5432,3306,1433,1521"
-    },
-    {
-      protocol    = "tcp"
-      description = "Allow access to RDS"
-      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az2
-      ports       = "5432,3306,1433,1521"
-    },
-    {
-      protocol    = "tcp"
-      description = "Allow access to RDS"
-      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az3
-      ports       = "5432,3306,1433,1521"
-    },
-    {
-      protocol    = "tcp"
-      description = "Allow access to RDS"
-      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az4
-      ports       = "5432,3306,1433,1521"
-    },
-    # Elasticache access
-    {
-      protocol    = "tcp"
-      description = "Allow access to Elasticache"
-      destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az1
-      ports       = "6379"
-    },
-    {
-      protocol    = "tcp"
-      description = "Allow access to Elasticache"
-      destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az2
-      ports       = "6379"
-    },
-    # Elastisearch access
-    {
-      protocol    = "tcp"
-      description = "Allow access to AWS Elasticsearch"
-      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az1
-      ports       = "443"
-    },
-    {
-      protocol    = "tcp"
-      description = "Allow access to AWS Elasticsearch"
-      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
-      ports       = "443"
-    },
-    {
-      protocol    = "tcp"
-      description = "Allow access to AWS Elasticsearch"
-      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az3
-      ports       = "443"
-    },
-    {
-      protocol    = "tcp"
-      description = "Allow access to AWS Elasticsearch"
-      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az4
-      ports       = "443"
-    },
-    # S3 Gateway access
-    {
-      for_each = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs
-      protocol    = "tcp"
-      description = "Allow access to AWS S3 Gateway"
-      destination = each.value
-      ports       = "443"
-    },
-  ]
+  rules = local.trusted_local_networks_egress_rules
+
   provider = cloudfoundryv3
 }
 
@@ -289,6 +341,7 @@ resource "cloudfoundry_security_group" "brokers" {
     destination = "169.254.169.254"
     ports       = "80"
     description = "AWS Metadata Service"
+    log = false
   }]
   running_spaces = [cloudfoundry_space.services.id]
   provider = cloudfoundryv3
@@ -315,16 +368,15 @@ resource "cloudfoundry_security_group" "internal_services_egress" {
       description = "Allow access to internal services on port 443 - AZ 1"
       destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az1
       ports       = "443"
+      log = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to internal services on port 443 - AZ 2"
       destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az2
       ports       = "443"
+      log = false
     },
   ]
   provider = cloudfoundryv3
 }
-
-
-

--- a/terraform/stacks/cf/asg.tf
+++ b/terraform/stacks/cf/asg.tf
@@ -1,332 +1,330 @@
-resource "cloudfoundry_asg" "public_networks" {
+#renamed resource
+resource "cloudfoundry_security_group" "public_networks" {
   name = "public_networks"
-
-  rule {
-    protocol    = "all"
-    destination = "0.0.0.0-9.255.255.255"
-  }
-
-  rule {
-    protocol    = "all"
-    destination = "11.0.0.0-169.253.255.255"
-  }
-
-  rule {
-    protocol    = "all"
-    destination = "169.255.0.0-172.15.255.255"
-  }
-
-  rule {
-    protocol    = "all"
-    destination = "172.32.0.0-192.167.255.255"
-  }
-
-  rule {
-    protocol    = "all"
-    destination = "192.169.0.0-255.255.255.255"
-  }
+  rules = [
+    {
+      protocol    = "all"
+      destination = "0.0.0.0-9.255.255.255"
+    },
+    {
+      protocol    = "all"
+      destination = "11.0.0.0-169.253.255.255"
+    },
+    {
+      protocol    = "all"
+      destination = "169.255.0.0-172.15.255.255"
+    },
+    {
+      protocol    = "all"
+      destination = "172.32.0.0-192.167.255.255"
+    },
+    {
+      protocol    = "all"
+      destination = "192.169.0.0-255.255.255.255"
+  }, ]
+  staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
+  running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
+  provider = cloudfoundryv3
 }
+
 
 # New public_networks asg to apply to spaces individually, not globally.
-
-resource "cloudfoundry_asg" "public_networks_egress" {
+#renamed resource
+resource "cloudfoundry_security_group" "public_networks_egress" {
   name = "public_networks_egress"
 
-  rule {
-    protocol    = "all"
-    destination = "0.0.0.0-9.255.255.255"
-  }
+  globally_enabled_staging = true
 
-  rule {
-    protocol    = "all"
-    destination = "11.0.0.0-169.253.255.255"
-  }
+  rules = [
 
-  rule {
-    protocol    = "all"
-    destination = "169.255.0.0-172.15.255.255"
-  }
-
-  rule {
-    protocol    = "all"
-    destination = "172.32.0.0-192.167.255.255"
-  }
-
-  rule {
-    protocol    = "all"
-    destination = "192.169.0.0-255.255.255.255"
-  }
-
-  rule {
-    description = "Rule for private endpoint to s3 in region"
-    protocol    = "tcp"
-    destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if1_ip
-    ports       = "443"
-  }
-
-  rule {
-    description = "Rule for private endpoint to s3 in region"
-    protocol    = "tcp"
-    destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if2_ip
-    ports       = "443"
-  }
-
+    {
+      protocol    = "all"
+      destination = "0.0.0.0-9.255.255.255"
+    },
+    {
+      protocol    = "all"
+      destination = "11.0.0.0-169.253.255.255"
+    },
+    {
+      protocol    = "all"
+      destination = "169.255.0.0-172.15.255.255"
+    },
+    {
+      protocol    = "all"
+      destination = "172.32.0.0-192.167.255.255"
+    },
+    {
+      protocol    = "all"
+      destination = "192.169.0.0-255.255.255.255"
+    },
+    {
+      description = "Rule for private endpoint to s3 in region"
+      protocol    = "tcp"
+      destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if1_ip
+      ports       = "443"
+    },
+    {
+      description = "Rule for private endpoint to s3 in region"
+      protocol    = "tcp"
+      destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if2_ip
+      ports       = "443"
+    },
+  ]
+  provider = cloudfoundryv3
 }
 
-resource "cloudfoundry_asg" "dns" {
-  name = "dns"
+#renamed resource
+resource "cloudfoundry_security_group" "dns" {
+  name                     = "dns"
+  globally_enabled_running = true
+  globally_enabled_staging = true
 
-  rule {
-    protocol    = "tcp"
-    ports       = "53"
-    destination = "0.0.0.0/0"
-  }
-
-  rule {
-    protocol    = "udp"
-    ports       = "53"
-    destination = "0.0.0.0/0"
-  }
+  rules = [
+    {
+      protocol    = "tcp"
+      ports       = "53"
+      destination = "0.0.0.0/0"
+    },
+    {
+      protocol    = "udp"
+      ports       = "53"
+      destination = "0.0.0.0/0"
+    },
+  ]
+  staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
+  running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
+  provider = cloudfoundryv3
 }
 
 # New dns asg to apply to spaces individually, not globally.
 
-resource "cloudfoundry_asg" "dns_egress" {
+#renamed resource
+resource "cloudfoundry_security_group" "dns_egress" {
   name = "dns_egress"
 
-  rule {
-    protocol    = "tcp"
-    ports       = "53"
-    destination = "0.0.0.0/0"
-  }
-
-  rule {
-    protocol    = "udp"
-    ports       = "53"
-    destination = "0.0.0.0/0"
-  }
+  rules = [
+    {
+      protocol    = "tcp"
+      ports       = "53"
+      destination = "0.0.0.0/0"
+    },
+    {
+      protocol    = "udp"
+      ports       = "53"
+      destination = "0.0.0.0/0"
+    },
+  ]
+  provider = cloudfoundryv3
 }
 
-resource "cloudfoundry_asg" "trusted_local_networks" {
+#renamed resource
+resource "cloudfoundry_security_group" "trusted_local_networks" {
   name = "trusted_local_networks"
 
   # RDS access for postgres, mysql, mssql, oracle
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to RDS"
-    destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az1
-    ports       = "5432,3306,1433,1521"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to RDS"
-    destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az2
-    ports       = "5432,3306,1433,1521"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to RDS"
-    destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az3
-    ports       = "5432,3306,1433,1521"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to RDS"
-    destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az4
-    ports       = "5432,3306,1433,1521"
-  }
-
-  # Elasticache access
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to Elasticache"
-    destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az1
-    ports       = "6379"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to Elasticache"
-    destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az2
-    ports       = "6379"
-  }
-
-  # Elastisearch access
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS Elasticsearch"
-    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az1
-    ports       = "443"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS Elasticsearch"
-    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
-    ports       = "443"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS Elasticsearch"
-    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az3
-    ports       = "443"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS Elasticsearch"
-    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az4
-    ports       = "443"
-  }
-  # S3 Gateway access
-  dynamic "rule" {
-
-    for_each = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs
-    iterator = rule
-
-    content {
+  rules = [
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az1
+      ports       = "5432,3306,1433,1521"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az2
+      ports       = "5432,3306,1433,1521"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az3
+      ports       = "5432,3306,1433,1521"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az4
+      ports       = "5432,3306,1433,1521"
+    },
+    # Elasticache access
+    {
+      protocol    = "tcp"
+      description = "Allow access to Elasticache"
+      destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az1
+      ports       = "6379"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to Elasticache"
+      destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az2
+      ports       = "6379"
+    },
+    # Elastisearch access
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az1
+      ports       = "443"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
+      ports       = "443"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az3
+      ports       = "443"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az4
+      ports       = "443"
+    },
+    # S3 Gateway access
+    {
+      for_each    = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs
       protocol    = "tcp"
       description = "Allow access to AWS S3 Gateway"
-      destination = rule.value
+      destination = each.value
       ports       = "443"
-    }
-  }
+    },
+  ]
+  staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.email.id]
+  running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.email.id]
+  provider = cloudfoundryv3
 }
 
 # New trusted networks asg to apply to spaces individually, not globally.
 
-resource "cloudfoundry_asg" "trusted_local_networks_egress" {
+resource "cloudfoundry_security_group" "trusted_local_networks_egress" {
   name = "trusted_local_networks_egress"
 
+  globally_enabled_staging = true
+
   # RDS access for postgres, mysql, mssql, oracle
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to RDS"
-    destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az1
-    ports       = "5432,3306,1433,1521"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to RDS"
-    destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az2
-    ports       = "5432,3306,1433,1521"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to RDS"
-    destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az3
-    ports       = "5432,3306,1433,1521"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to RDS"
-    destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az4
-    ports       = "5432,3306,1433,1521"
-  }
-
-  # Elasticache access
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to Elasticache"
-    destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az1
-    ports       = "6379"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to Elasticache"
-    destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az2
-    ports       = "6379"
-  }
-
-  # Elastisearch access
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS Elasticsearch"
-    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az1
-    ports       = "443"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS Elasticsearch"
-    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
-    ports       = "443"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS Elasticsearch"
-    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az3
-    ports       = "443"
-  }
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to AWS Elasticsearch"
-    destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az4
-    ports       = "443"
-  }
-  # S3 Gateway access
-  dynamic "rule" {
-
-    for_each = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs
-    iterator = rule
-
-    content {
+  rules = [
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az1
+      ports       = "5432,3306,1433,1521"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az2
+      ports       = "5432,3306,1433,1521"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az3
+      ports       = "5432,3306,1433,1521"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to RDS"
+      destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az4
+      ports       = "5432,3306,1433,1521"
+    },
+    # Elasticache access
+    {
+      protocol    = "tcp"
+      description = "Allow access to Elasticache"
+      destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az1
+      ports       = "6379"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to Elasticache"
+      destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az2
+      ports       = "6379"
+    },
+    # Elastisearch access
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az1
+      ports       = "443"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
+      ports       = "443"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az3
+      ports       = "443"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to AWS Elasticsearch"
+      destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az4
+      ports       = "443"
+    },
+    # S3 Gateway access
+    {
+      for_each = data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs
       protocol    = "tcp"
       description = "Allow access to AWS S3 Gateway"
-      destination = rule.value
+      destination = each.value
       ports       = "443"
-    }
-  }
+    },
+  ]
+  provider = cloudfoundryv3
 }
 
-resource "cloudfoundry_asg" "brokers" {
+resource "cloudfoundry_security_group" "brokers" {
   name = "brokers"
-  rule {
+  rules = [{
     protocol    = "tcp"
     destination = "169.254.169.254"
     ports       = "80"
     description = "AWS Metadata Service"
-  }
-
+  }]
+  running_spaces = [cloudfoundry_space.services.id]
+  provider = cloudfoundryv3
 }
 
-resource "cloudfoundry_asg" "smtp" {
+resource "cloudfoundry_security_group" "smtp" {
   name = "smtp"
-  rule {
+  rules = [{
     destination = data.terraform_remote_state.tooling.outputs.production_smtp_private_ip
     description = "SMTP relay"
     protocol    = "tcp"
     ports       = "25"
-  }
+  }]
+  running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.email.id]
+  provider = cloudfoundryv3
 }
 
-resource "cloudfoundry_asg" "internal_services_egress" {
+resource "cloudfoundry_security_group" "internal_services_egress" {
   name = "internal_services_egress"
 
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to internal services on port 443 - AZ 1"
-    destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az1
-    ports       = "443"
-  }
-
-  rule {
-    protocol    = "tcp"
-    description = "Allow access to internal services on port 443 - AZ 2"
-    destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az2
-    ports       = "443"
-  }
-}
-
-# Default global running ASG
-resource "cloudfoundry_default_asg" "running" {
-  name = "running"
-  asgs = [cloudfoundry_asg.dns.id]
-}
-
-# Default global staging ASG
-resource "cloudfoundry_default_asg" "staging" {
-  name = "staging"
-  asgs = [
-    cloudfoundry_asg.dns.id,
-    cloudfoundry_asg.public_networks_egress.id,
-    cloudfoundry_asg.trusted_local_networks_egress.id,
+  rules = [
+    {
+      protocol    = "tcp"
+      description = "Allow access to internal services on port 443 - AZ 1"
+      destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az1
+      ports       = "443"
+    },
+    {
+      protocol    = "tcp"
+      description = "Allow access to internal services on port 443 - AZ 2"
+      destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az2
+      ports       = "443"
+    },
   ]
+  provider = cloudfoundryv3
 }
+
+
 

--- a/terraform/stacks/cf/asg.tf
+++ b/terraform/stacks/cf/asg.tf
@@ -37,6 +37,7 @@ resource "cloudfoundry_security_group" "public_networks" {
 resource "cloudfoundry_security_group" "public_networks_egress" {
   name = "public_networks_egress"
 
+  globally_enabled_running = false
   globally_enabled_staging = true
 
   rules = [
@@ -111,6 +112,9 @@ resource "cloudfoundry_security_group" "dns" {
 # New dns asg to apply to spaces individually, not globally.
 resource "cloudfoundry_security_group" "dns_egress" {
   name = "dns_egress"
+
+  globally_enabled_running = false
+  globally_enabled_staging = false
 
   rules = [
     {
@@ -326,6 +330,7 @@ locals {
 resource "cloudfoundry_security_group" "trusted_local_networks_egress" {
   name = "trusted_local_networks_egress"
 
+  globally_enabled_running = false
   globally_enabled_staging = true
 
   # RDS access for postgres, mysql, mssql, oracle

--- a/terraform/stacks/cf/asg.tf
+++ b/terraform/stacks/cf/asg.tf
@@ -1,35 +1,37 @@
 resource "cloudfoundry_security_group" "public_networks" {
-  name = "public_networks"
+  name                     = "public_networks"
+  globally_enabled_running = false
+  globally_enabled_staging = false
   rules = [
     {
       protocol    = "all"
       destination = "0.0.0.0-9.255.255.255"
-      log = false
+      log         = false
     },
     {
       protocol    = "all"
       destination = "11.0.0.0-169.253.255.255"
-      log = false
+      log         = false
     },
     {
       protocol    = "all"
       destination = "169.255.0.0-172.15.255.255"
-      log = false
+      log         = false
     },
     {
       protocol    = "all"
       destination = "172.32.0.0-192.167.255.255"
-      log = false
+      log         = false
     },
     {
       protocol    = "all"
       destination = "192.169.0.0-255.255.255.255"
-      log = false
-    }, 
+      log         = false
+    },
   ]
-  staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
-  running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
-  provider = cloudfoundryv3
+  staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
+  running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
+  provider       = cloudfoundryv3
 }
 
 
@@ -45,41 +47,41 @@ resource "cloudfoundry_security_group" "public_networks_egress" {
     {
       protocol    = "all"
       destination = "0.0.0.0-9.255.255.255"
-      log = false
+      log         = false
     },
     {
       protocol    = "all"
       destination = "11.0.0.0-169.253.255.255"
-      log = false
+      log         = false
     },
     {
       protocol    = "all"
       destination = "169.255.0.0-172.15.255.255"
-      log = false
+      log         = false
     },
     {
       protocol    = "all"
       destination = "172.32.0.0-192.167.255.255"
-      log = false
+      log         = false
     },
     {
       protocol    = "all"
       destination = "192.169.0.0-255.255.255.255"
-      log = false
+      log         = false
     },
     {
       description = "Rule for private endpoint to s3 in region"
       protocol    = "tcp"
       destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if1_ip
       ports       = "443"
-      log = false
+      log         = false
     },
     {
       description = "Rule for private endpoint to s3 in region"
       protocol    = "tcp"
       destination = data.terraform_remote_state.iaas.outputs.vpc_endpoint_customer_s3_if2_ip
       ports       = "443"
-      log = false
+      log         = false
     },
   ]
   provider = cloudfoundryv3
@@ -95,18 +97,18 @@ resource "cloudfoundry_security_group" "dns" {
       protocol    = "tcp"
       ports       = "53"
       destination = "0.0.0.0/0"
-      log = false
+      log         = false
     },
     {
       protocol    = "udp"
       ports       = "53"
       destination = "0.0.0.0/0"
-      log = false
+      log         = false
     },
   ]
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
-  provider = cloudfoundryv3
+  provider       = cloudfoundryv3
 }
 
 # New dns asg to apply to spaces individually, not globally.
@@ -121,13 +123,13 @@ resource "cloudfoundry_security_group" "dns_egress" {
       protocol    = "tcp"
       ports       = "53"
       destination = "0.0.0.0/0"
-      log = false
+      log         = false
     },
     {
       protocol    = "udp"
       ports       = "53"
       destination = "0.0.0.0/0"
-      log = false
+      log         = false
     },
   ]
   provider = cloudfoundryv3
@@ -142,28 +144,28 @@ locals {
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az1
       ports       = "5432,3306,1433,1521"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az2
       ports       = "5432,3306,1433,1521"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az3
       ports       = "5432,3306,1433,1521"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az4
       ports       = "5432,3306,1433,1521"
-      log = false
+      log         = false
     },
     # Elasticache access
     {
@@ -171,14 +173,14 @@ locals {
       description = "Allow access to Elasticache"
       destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az1
       ports       = "6379"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to Elasticache"
       destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az2
       ports       = "6379"
-      log = false
+      log         = false
     },
     # Elastisearch access
     {
@@ -186,39 +188,39 @@ locals {
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az1
       ports       = "443"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
       ports       = "443"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az3
       ports       = "443"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az4
       ports       = "443"
-      log = false
+      log         = false
     },
   ]
 
   trusted_local_networks_rules_2 = [
     for cidr in data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs :
-    { 
+    {
       protocol    = "tcp"
       description = "Allow access to AWS S3 Gateway"
       destination = cidr
       ports       = "443"
-      log = false
+      log         = false
     }
   ]
 
@@ -233,7 +235,7 @@ resource "cloudfoundry_security_group" "trusted_local_networks" {
 
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.email.id]
-  provider = cloudfoundryv3
+  provider       = cloudfoundryv3
 }
 
 locals {
@@ -243,28 +245,28 @@ locals {
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az1
       ports       = "5432,3306,1433,1521"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az2
       ports       = "5432,3306,1433,1521"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az3
       ports       = "5432,3306,1433,1521"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to RDS"
       destination = data.terraform_remote_state.iaas.outputs.rds_subnet_cidr_az4
       ports       = "5432,3306,1433,1521"
-      log = false
+      log         = false
     },
     # Elasticache access
     {
@@ -272,14 +274,14 @@ locals {
       description = "Allow access to Elasticache"
       destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az1
       ports       = "6379"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to Elasticache"
       destination = data.terraform_remote_state.iaas.outputs.elasticache_subnet_cidr_az2
       ports       = "6379"
-      log = false
+      log         = false
     },
     # Elastisearch access
     {
@@ -287,39 +289,39 @@ locals {
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az1
       ports       = "443"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az2
       ports       = "443"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az3
       ports       = "443"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to AWS Elasticsearch"
       destination = data.terraform_remote_state.iaas.outputs.elasticsearch_subnet_cidr_az4
       ports       = "443"
-      log = false
+      log         = false
     },
   ]
 
   trusted_local_networks_egress_rules_2 = [
     for cidr in data.terraform_remote_state.iaas.outputs.s3_gateway_endpoint_cidrs :
-    { 
+    {
       protocol    = "tcp"
       description = "Allow access to AWS S3 Gateway"
       destination = cidr
       ports       = "443"
-      log = false
+      log         = false
     }
   ]
 
@@ -346,10 +348,10 @@ resource "cloudfoundry_security_group" "brokers" {
     destination = "169.254.169.254"
     ports       = "80"
     description = "AWS Metadata Service"
-    log = false
+    log         = false
   }]
   running_spaces = [cloudfoundry_space.services.id]
-  provider = cloudfoundryv3
+  provider       = cloudfoundryv3
 }
 
 resource "cloudfoundry_security_group" "smtp" {
@@ -361,7 +363,7 @@ resource "cloudfoundry_security_group" "smtp" {
     ports       = "25"
   }]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.email.id]
-  provider = cloudfoundryv3
+  provider       = cloudfoundryv3
 }
 
 resource "cloudfoundry_security_group" "internal_services_egress" {
@@ -373,14 +375,14 @@ resource "cloudfoundry_security_group" "internal_services_egress" {
       description = "Allow access to internal services on port 443 - AZ 1"
       destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az1
       ports       = "443"
-      log = false
+      log         = false
     },
     {
       protocol    = "tcp"
       description = "Allow access to internal services on port 443 - AZ 2"
       destination = data.terraform_remote_state.iaas.outputs.services_subnet_cidr_az2
       ports       = "443"
-      log = false
+      log         = false
     },
   ]
   provider = cloudfoundryv3

--- a/terraform/stacks/cf/asg.tf
+++ b/terraform/stacks/cf/asg.tf
@@ -31,7 +31,6 @@ resource "cloudfoundry_security_group" "public_networks" {
   ]
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
-  provider       = cloudfoundryv3
 }
 
 
@@ -84,7 +83,6 @@ resource "cloudfoundry_security_group" "public_networks_egress" {
       log         = false
     },
   ]
-  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_security_group" "dns" {
@@ -108,7 +106,6 @@ resource "cloudfoundry_security_group" "dns" {
   ]
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
-  provider       = cloudfoundryv3
 }
 
 # New dns asg to apply to spaces individually, not globally.
@@ -132,10 +129,7 @@ resource "cloudfoundry_security_group" "dns_egress" {
       log         = false
     },
   ]
-  provider = cloudfoundryv3
 }
-
-
 
 locals {
   trusted_local_networks_rules_1 = [
@@ -235,7 +229,6 @@ resource "cloudfoundry_security_group" "trusted_local_networks" {
 
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.email.id]
-  provider       = cloudfoundryv3
 }
 
 locals {
@@ -337,8 +330,6 @@ resource "cloudfoundry_security_group" "trusted_local_networks_egress" {
 
   # RDS access for postgres, mysql, mssql, oracle
   rules = local.trusted_local_networks_egress_rules
-
-  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_security_group" "brokers" {
@@ -351,7 +342,6 @@ resource "cloudfoundry_security_group" "brokers" {
     log         = false
   }]
   running_spaces = [cloudfoundry_space.services.id]
-  provider       = cloudfoundryv3
 }
 
 resource "cloudfoundry_security_group" "smtp" {
@@ -363,7 +353,6 @@ resource "cloudfoundry_security_group" "smtp" {
     ports       = "25"
   }]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.email.id]
-  provider       = cloudfoundryv3
 }
 
 resource "cloudfoundry_security_group" "internal_services_egress" {
@@ -385,5 +374,4 @@ resource "cloudfoundry_security_group" "internal_services_egress" {
       log         = false
     },
   ]
-  provider = cloudfoundryv3
 }

--- a/terraform/stacks/cf/iso.tf
+++ b/terraform/stacks/cf/iso.tf
@@ -8,5 +8,6 @@ resource "cloudfoundry_isolation_segment_entitlement" "platform" {
   orgs = [
     cloudfoundry_org.cloud-gov.id
   ]
+  default = false
   provider = cloudfoundryv3
 }

--- a/terraform/stacks/cf/iso.tf
+++ b/terraform/stacks/cf/iso.tf
@@ -1,5 +1,6 @@
 resource "cloudfoundry_isolation_segment" "platform" {
   name = "platform"
+  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_isolation_segment_entitlement" "platform" {
@@ -7,4 +8,5 @@ resource "cloudfoundry_isolation_segment_entitlement" "platform" {
   orgs = [
     cloudfoundry_org.cloud-gov.id
   ]
+  provider = cloudfoundryv3
 }

--- a/terraform/stacks/cf/iso.tf
+++ b/terraform/stacks/cf/iso.tf
@@ -1,6 +1,5 @@
 resource "cloudfoundry_isolation_segment" "platform" {
   name = "platform"
-  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_isolation_segment_entitlement" "platform" {
@@ -9,5 +8,4 @@ resource "cloudfoundry_isolation_segment_entitlement" "platform" {
     cloudfoundry_org.cloud-gov.id
   ]
   default = false
-  provider = cloudfoundryv3
 }

--- a/terraform/stacks/cf/orgs.tf
+++ b/terraform/stacks/cf/orgs.tf
@@ -1,16 +1,13 @@
 resource "cloudfoundry_org" "cloud-gov" {
-  name  = "cloud-gov"
-  provider = cloudfoundryv3
+  name = "cloud-gov"
 }
 
 resource "cloudfoundry_org" "acceptance_tests" {
   name = "cloud-gov-acceptance-tests"
-  provider = cloudfoundryv3
 }
 
 # Federalist/Pages
 
 data "cloudfoundry_org" "gsa-18f-federalist" {
-  name  = "gsa-18f-federalist"
-  provider = cloudfoundryv3
+  name = "gsa-18f-federalist"
 }

--- a/terraform/stacks/cf/orgs.tf
+++ b/terraform/stacks/cf/orgs.tf
@@ -1,15 +1,16 @@
 resource "cloudfoundry_org" "cloud-gov" {
   name  = "cloud-gov"
-  quota = cloudfoundry_org_quota.default-tts.id
+  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_org" "acceptance_tests" {
-  name  = "cloud-gov-acceptance-tests"
-  quota = cloudfoundry_org_quota.default-tts.id
+  name = "cloud-gov-acceptance-tests"
+  provider = cloudfoundryv3
 }
 
 # Federalist/Pages
 
 data "cloudfoundry_org" "gsa-18f-federalist" {
   name  = "gsa-18f-federalist"
+  provider = cloudfoundryv3
 }

--- a/terraform/stacks/cf/providers.tf
+++ b/terraform/stacks/cf/providers.tf
@@ -5,3 +5,6 @@ terraform {
 
 provider "cloudfoundry" {
 }
+
+provider "cloudfoundryV3" {
+}

--- a/terraform/stacks/cf/providers.tf
+++ b/terraform/stacks/cf/providers.tf
@@ -6,5 +6,5 @@ terraform {
 provider "cloudfoundry" {
 }
 
-provider "cloudfoundryV3" {
+provider "cloudfoundryv3" {
 }

--- a/terraform/stacks/cf/providers.tf
+++ b/terraform/stacks/cf/providers.tf
@@ -5,6 +5,3 @@ terraform {
 
 provider "cloudfoundry" {
 }
-
-provider "cloudfoundryv3" {
-}

--- a/terraform/stacks/cf/quotas.tf
+++ b/terraform/stacks/cf/quotas.tf
@@ -4,7 +4,6 @@ resource "cloudfoundry_org_quota" "default-tts" {
   total_memory             = 81920
   total_routes             = 1000
   total_services           = 200
-  total_route_ports        = -1
   orgs                     = [cloudfoundry_org.cloud-gov.id, cloudfoundry_org.acceptance_tests.id]
   provider = cloudfoundryv3
 }
@@ -15,9 +14,7 @@ resource "cloudfoundry_space_quota" "tiny" {
   name                     = "tiny-tf-managed"
   allow_paid_service_plans = true
   total_memory             = 1024
-  total_routes             = -1
-  total_services           = -1
-  total_route_ports        = -1
   org                     = data.cloudfoundry_org.gsa-18f-federalist.id
+  spaces = [cloudfoundry_space.email.id]
   provider = cloudfoundryv3
 }

--- a/terraform/stacks/cf/quotas.tf
+++ b/terraform/stacks/cf/quotas.tf
@@ -5,7 +5,6 @@ resource "cloudfoundry_org_quota" "default-tts" {
   total_routes             = 1000
   total_services           = 200
   orgs                     = [cloudfoundry_org.cloud-gov.id, cloudfoundry_org.acceptance_tests.id]
-  provider                 = cloudfoundryv3
 }
 
 # Federalist/ Pages
@@ -17,5 +16,4 @@ resource "cloudfoundry_space_quota" "tiny" {
   total_memory             = 1024
   org                      = data.cloudfoundry_org.gsa-18f-federalist.id
   spaces                   = [cloudfoundry_space.email.id]
-  provider                 = cloudfoundryv3
 }

--- a/terraform/stacks/cf/quotas.tf
+++ b/terraform/stacks/cf/quotas.tf
@@ -5,16 +5,19 @@ resource "cloudfoundry_org_quota" "default-tts" {
   total_routes             = 1000
   total_services           = 200
   total_route_ports        = -1
+  orgs                     = [cloudfoundry_org.cloud-gov.id, cloudfoundry_org.acceptance_tests.id]
+  provider = cloudfoundryv3
 }
 
 # Federalist/ Pages
 
 resource "cloudfoundry_space_quota" "tiny" {
-    name = "tiny-tf-managed"
-    allow_paid_service_plans = true
-    total_memory = 1024
-    total_routes             = -1
-    total_services           = -1
-    total_route_ports        = -1
-    org = data.cloudfoundry_org.gsa-18f-federalist.id
+  name                     = "tiny-tf-managed"
+  allow_paid_service_plans = true
+  total_memory             = 1024
+  total_routes             = -1
+  total_services           = -1
+  total_route_ports        = -1
+  org                     = data.cloudfoundry_org.gsa-18f-federalist.id
+  provider = cloudfoundryv3
 }

--- a/terraform/stacks/cf/quotas.tf
+++ b/terraform/stacks/cf/quotas.tf
@@ -5,7 +5,7 @@ resource "cloudfoundry_org_quota" "default-tts" {
   total_routes             = 1000
   total_services           = 200
   orgs                     = [cloudfoundry_org.cloud-gov.id, cloudfoundry_org.acceptance_tests.id]
-  provider = cloudfoundryv3
+  provider                 = cloudfoundryv3
 }
 
 # Federalist/ Pages
@@ -13,8 +13,9 @@ resource "cloudfoundry_org_quota" "default-tts" {
 resource "cloudfoundry_space_quota" "tiny" {
   name                     = "tiny-tf-managed"
   allow_paid_service_plans = true
+  total_app_tasks          = 5
   total_memory             = 1024
-  org                     = data.cloudfoundry_org.gsa-18f-federalist.id
-  spaces = [cloudfoundry_space.email.id]
-  provider = cloudfoundryv3
+  org                      = data.cloudfoundry_org.gsa-18f-federalist.id
+  spaces                   = [cloudfoundry_space.email.id]
+  provider                 = cloudfoundryv3
 }

--- a/terraform/stacks/cf/spaces.tf
+++ b/terraform/stacks/cf/spaces.tf
@@ -1,50 +1,42 @@
 resource "cloudfoundry_space" "services" {
-  name = "services"
-  org  = cloudfoundry_org.cloud-gov.id
+  name              = "services"
+  org               = cloudfoundry_org.cloud-gov.id
   isolation_segment = cloudfoundry_isolation_segment.platform.id
-  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "dashboard" {
   name = "dashboard"
   org  = cloudfoundry_org.cloud-gov.id
-  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "cg-ui" {
   name = "cg-ui"
   org  = cloudfoundry_org.cloud-gov.id
-  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "uaa-extras" {
   name = "uaa-extras"
   org  = cloudfoundry_org.cloud-gov.id
-  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "cspr-collector" {
   name = "cspr-collector"
   org  = cloudfoundry_org.cloud-gov.id
-  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "opensearch-dashboards-proxy" {
   name = "opensearch-dashboards-proxy"
   org  = cloudfoundry_org.cloud-gov.id
-  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "external_domain_broker_tests" {
   name = "external-domain-broker-tests"
   org  = cloudfoundry_org.acceptance_tests.id
-  provider = cloudfoundryv3
 }
 
 # Federalist/ Pages
 
 resource "cloudfoundry_space" "email" {
-  name  = "email"
-  org   = data.cloudfoundry_org.gsa-18f-federalist.id
-  provider = cloudfoundryv3
+  name = "email"
+  org  = data.cloudfoundry_org.gsa-18f-federalist.id
 }

--- a/terraform/stacks/cf/spaces.tf
+++ b/terraform/stacks/cf/spaces.tf
@@ -1,128 +1,50 @@
 resource "cloudfoundry_space" "services" {
   name = "services"
   org  = cloudfoundry_org.cloud-gov.id
-  asgs = [
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.dns.id,
-    cloudfoundry_asg.brokers.id,
-    cloudfoundry_asg.smtp.id,
-  ]
-  staging_asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-  ]
   isolation_segment = cloudfoundry_isolation_segment.platform.id
+  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "dashboard" {
   name = "dashboard"
   org  = cloudfoundry_org.cloud-gov.id
-  asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-    cloudfoundry_asg.smtp.id,
-  ]
-  staging_asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-  ]
+  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "cg-ui" {
   name = "cg-ui"
   org  = cloudfoundry_org.cloud-gov.id
-  asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-    cloudfoundry_asg.smtp.id,
-  ]
-  staging_asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-  ]
+  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "uaa-extras" {
   name = "uaa-extras"
   org  = cloudfoundry_org.cloud-gov.id
-  asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-    cloudfoundry_asg.smtp.id,
-  ]
-  staging_asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-  ]
+  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "cspr-collector" {
   name = "cspr-collector"
   org  = cloudfoundry_org.cloud-gov.id
-  asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-    cloudfoundry_asg.smtp.id,
-  ]
-  staging_asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-  ]
+  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "opensearch-dashboards-proxy" {
   name = "opensearch-dashboards-proxy"
   org  = cloudfoundry_org.cloud-gov.id
-  asgs = [
-    cloudfoundry_asg.public_networks_egress.id,
-    cloudfoundry_asg.dns.id,
-    cloudfoundry_asg.trusted_local_networks.id
-  ]
-  staging_asgs = [
-    cloudfoundry_asg.dns.id,
-    cloudfoundry_asg.public_networks_egress.id
-  ]
+  provider = cloudfoundryv3
 }
 
 resource "cloudfoundry_space" "external_domain_broker_tests" {
   name = "external-domain-broker-tests"
   org  = cloudfoundry_org.acceptance_tests.id
-  asgs = [
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-  ]
-  staging_asgs = [
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-  ]
+  provider = cloudfoundryv3
 }
 
 # Federalist/ Pages
 
 resource "cloudfoundry_space" "email" {
-  name = "email"
-  org  = data.cloudfoundry_org.gsa-18f-federalist.id
-  quota = cloudfoundry_space_quota.tiny.id
-  asgs = [
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-    cloudfoundry_asg.smtp.id,
-  ]
-  staging_asgs = [
-    cloudfoundry_asg.trusted_local_networks.id,
-    cloudfoundry_asg.public_networks.id,
-    cloudfoundry_asg.dns.id,
-  ]
+  name  = "email"
+  org   = data.cloudfoundry_org.gsa-18f-federalist.id
+  provider = cloudfoundryv3
 }

--- a/terraform/stacks/cf/versions.tf
+++ b/terraform/stacks/cf/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "cloudfoundry-community/cloudfoundry"
       version = "0.53.0"
     }
+    cloudfoundryv3 = {
+      source  = "cloudfoundry/cloudfoundry"
+      version = "1.4.0"
+    }
   }
 }

--- a/terraform/stacks/cf/versions.tf
+++ b/terraform/stacks/cf/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 0.14"
   required_providers {
-    cloudfoundryv3 = {
+    cloudfoundry = {
       source  = "cloudfoundry/cloudfoundry"
       version = "< 2.0"
     }

--- a/terraform/stacks/cf/versions.tf
+++ b/terraform/stacks/cf/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     cloudfoundryv3 = {
       source  = "cloudfoundry/cloudfoundry"
-      version = "1.4.0"
+      version = "< 2.0"
     }
   }
 }

--- a/terraform/stacks/cf/versions.tf
+++ b/terraform/stacks/cf/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_version = ">= 0.14"
   required_providers {
-    cloudfoundry = {
-      source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.53.0"
-    }
     cloudfoundryv3 = {
       source  = "cloudfoundry/cloudfoundry"
       version = "< 2.0"


### PR DESCRIPTION
## Changes proposed in this pull request:

**Now merging the right thing into the right destination!**

This PR upgrades the terraform provider from the cloudfoundry-community version, which leverages v2 of the CF API, with the cloudfoundry version, that leverages V3 of the CF API. 

This is a PR of the final state of the `.tf` files. This branch contains interim commits used to remove the old resources from the state file then import the resources under the new provider. After merging the PR, the branch will be manually restored and used to upgrade staging and production.

The staging upgrade may require additional changes as the `test_cdn` is not implemented in dev and therefore could not be tested. https://github.com/cloud-gov/deploy-cf/blob/b0c3e4f7a7df655755ca35ba510d401ed9d83701/terraform/stacks/cf/apps.tf#L2

Additionally:

- The upgrade process is not implemented as a concourse job or task. The provider versions do not have resource parity. The upgrade is achieved via a temporary script with a manual statefile intervention to deal with a non-importable resource. The script will be deleted after the upgrades are complete. https://github.com/cloud-gov/deploy-cf/blob/cf-provider-v3/terraform/scripts/update-provider.sh

- Each environment will be updated individually. Production will be scheduled with the maintenance engineer. 

- This update should not result in any changes to the infrastructure (only terraform state).

- The terraform plan and apply jobs in concourse are paused for each environment and will be unpaused when the state has been updated with no changes detected. 

## security considerations

None
