### PR TITLE
Update test_cdn module to v3

### DIFF
--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -24,7 +24,7 @@ resource "null_resource" "git_clone" {
   }
 
   provisioner "local-exec" {
-    command = "mkdir -p \"${local.clone_dir}\" && git clone ${var.source_code_repo} ${local.clone_dir}"
+    command = "if [ ! -d \"${local.clone_dir}\" ]; then git clone ${var.source_code_repo} ${local.clone_dir}; fi"
   }
 }
 

--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -57,11 +57,12 @@ resource "cloudfoundry_app" "test-cdn" {
   name             = "test-cdn"
   buildpacks       = ["staticfile_buildpack"]
   org_name         = var.organization_id
-  space_name       = data.cloudfoundry_space.hello_worlds.id
+  space_name       = data.cloudfoundry_space.hello_worlds.name
   path             = local.zip_output_filepath
   source_code_hash = data.archive_file.test_cdn_app_src.output_sha256
 
   routes = [{
+    protocol = "http1"
     route = cloudfoundry_route.test_cdn_route.url
   }]
 }

--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -24,7 +24,7 @@ resource "null_resource" "git_clone" {
   }
 
   provisioner "local-exec" {
-    command = "mkdir -p \"${local.clone_dir}\" ]; then git clone ${var.source_code_repo} ${local.clone_dir};"
+    command = "mkdir -p \"${local.clone_dir}\" && git clone ${var.source_code_repo} ${local.clone_dir}"
   }
 }
 

--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -62,6 +62,6 @@ resource "cloudfoundry_app" "test-cdn" {
   source_code_hash = data.archive_file.test_cdn_app_src.output_sha256
 
   routes = [{
-    route = cloudfoundry_route.test_cdn_route.id
+    route = cloudfoundry_route.test_cdn_route.url
   }]
 }

--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -13,6 +13,10 @@ data "cloudfoundry_service_plan" "external_domain" {
   name                  = "domain-with-cdn-dedicated-waf"
 }
 
+data "cloudfoundry_org" "org" {
+  name = var.organization_name
+}
+
 data "cloudfoundry_space" "hello_worlds" {
   name = var.space_name
   org  = var.organization_id
@@ -56,7 +60,7 @@ resource "cloudfoundry_service_instance" "test_cdn_instance" {
 resource "cloudfoundry_app" "test-cdn" {
   name             = "test-cdn"
   buildpacks       = ["staticfile_buildpack"]
-  org_name         = var.organization_id
+  org_name         = data.cloudfoundry_org.org.name
   space_name       = data.cloudfoundry_space.hello_worlds.name
   path             = local.zip_output_filepath
   source_code_hash = data.archive_file.test_cdn_app_src.output_sha256

--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -19,7 +19,7 @@ data "cloudfoundry_org" "org" {
 
 data "cloudfoundry_space" "hello_worlds" {
   name = var.space_name
-  org  = var.organization_id
+  org  = data.cloudfoundry_org.org.id
 }
 
 resource "null_resource" "git_clone" {
@@ -64,6 +64,15 @@ resource "cloudfoundry_app" "test-cdn" {
   space_name       = data.cloudfoundry_space.hello_worlds.name
   path             = local.zip_output_filepath
   source_code_hash = data.archive_file.test_cdn_app_src.output_sha256
+  memory = "512M"
+  disk_quota = "1024M"
+  enable_ssh = true
+  health_check_type = "port"
+  instances = 1
+  log_rate_limit_per_second = "-1"
+  readiness_health_check_type = "process"
+  stack = "cflinuxfs4"
+
 
   routes = [{
     protocol = "http1"

--- a/terraform/modules/test_cdn/test_cdn.tf
+++ b/terraform/modules/test_cdn/test_cdn.tf
@@ -24,7 +24,7 @@ resource "null_resource" "git_clone" {
   }
 
   provisioner "local-exec" {
-    command = "if [ ! -d \"${local.clone_dir}\" ]; then git clone ${var.source_code_repo} ${local.clone_dir}; fi"
+    command = "mkdir -p \"${local.clone_dir}\" ]; then git clone ${var.source_code_repo} ${local.clone_dir};"
   }
 }
 

--- a/terraform/modules/test_cdn/variables.tf
+++ b/terraform/modules/test_cdn/variables.tf
@@ -1,9 +1,9 @@
 variable "iaas_stack_name" {
 }
 
-variable "organization_id" {
+variable "organization_name" {
   type = string
-  description = "Organization GUID to use for test CDN app"
+  description = "Organization name to use for test CDN app"
 }
 
 variable "space_name" {

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -117,8 +117,13 @@ pushd $this_directory/../stacks/cf
                         new_type="$existing_type"
                         ;;
                 esac
-                echo "Importing "${new_type}.${name}" $tf_id"
-                terraform import -var-file=${env}.tfvars "${new_type}.${name}" "$tf_id"
+                if [[ "$address" =~ ^module* ]]; then
+                    echo "Importing ${address} $tf_id"
+                    terraform import -var-file=${env}.tfvars "${address}" "$tf_id"
+                else 
+                    echo "Importing ${new_type}.${name} $tf_id"
+                    terraform import -var-file=${env}.tfvars "${new_type}.${name}" "$tf_id"
+                fi
             fi
         fi
     done

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -140,7 +140,7 @@ pushd $this_directory/../stacks/cf
         "-backend-config=region=us-gov-west-1"
     )
     terraform init -upgrade "${init_args[@]}"
-    changes=$(terraform plan -json -var-file=dev.tfvars -out output | tail -n 1 | jq -r '.changes')
+    changes=$(terraform plan -json -var-file=${env}.tfvars -out output | tail -n 1 | jq -r '.changes')
     to_add=$(echo "$changes" | jq -r '.add')
     to_change=$(echo "$changes" | jq -r '.change')
     to_import=$(echo "$changes" | jq -r '.import')

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -56,7 +56,7 @@ pushd $this_directory/../stacks/cf
     read user_input
 
     # Dual provider with v3 tf
-    git checkout f6a83b5e7e2f093308ef3e923cd95e2da5fc0d41
+    git checkout 7749388b8db0d6f0c325d2393af77ccbb63f0295
 
     if [[ "$env" == "dev" ]]; then
         backend_config_key="cf-development/terraform.tfstate"

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -56,7 +56,7 @@ pushd $this_directory/../stacks/cf
     read user_input
 
     # Dual provider with v3 tf
-    git checkout 1ab655c7ddf9ffdf346870dc2ca32bf20d8c1caf
+    git checkout 3a10959c8e95203e038e132a0b7cebcf7ec1aa4d
 
     if [[ "$env" == "dev" ]]; then
         backend_config_key="cf-development/terraform.tfstate"

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -90,7 +90,13 @@ pushd $this_directory/../stacks/cf
                 exit 1
             else 
                 tf_id=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.resources[] | select(.address==$address) | .values.id')
+                if [ -z "$tf_id" ]; then
+                    tf_id=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.child_modules[].resources[] | select(.address==$address) | .values.id')
+                fi 
                 name=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.resources[] | select(.address==$address) | .name')
+                if [ -z "$name" ]; then
+                    name=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.child_modules[].resources[] | select(.address==$address) | .name')
+                fi 
                 case $existing_type in
                     cloudfoundry_asg)
                         new_type="cloudfoundry_security_group"

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -58,7 +58,7 @@ pushd $this_directory/../stacks/cf
     read user_input
 
     # Dual provider with v3 tf
-    git checkout 286dc0c83f1b413ed67067d311e67b977aa85b1f
+    git checkout f6a83b5e7e2f093308ef3e923cd95e2da5fc0d41
 
     if [[ "$env" == "dev" ]]; then
         backend_config_key="cf-development/terraform.tfstate"

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -60,6 +60,24 @@ pushd $this_directory/../stacks/cf
     # Dual provider with v3 tf
     git checkout 286dc0c83f1b413ed67067d311e67b977aa85b1f
 
+    if [[ "$env" == "dev" ]]; then
+        backend_config_key="cf-development/terraform.tfstate"
+    elif [[ "$env" == "stage" ]]; then
+        backend_config_key="cf-staging/terraform.tfstate"
+    elif [[ "$env" == "prod" ]]; then
+        backend_config_key="cf-production/terraform.tfstate"
+    else 
+        echo "Missing backend_config_key for the environment ${env}. Exiting."
+    fi
+    init_args=(
+        "-backend=true"
+        "-backend-config=encrypt=true"
+        "-backend-config=bucket=terraform-state"
+        "-backend-config=key=${backend_config_key}"
+        "-backend-config=region=us-gov-west-1"
+    )
+    terraform init -upgrade "${init_args[@]}"
+
     for address in $addresses; do
         if [[ "$address" =~ ^data* ]]; then
             echo "Skipping import of data object: $address"

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -104,16 +104,16 @@ pushd $this_directory/../stacks/cf
             terraform import -var-file=${env}.tfvars "${new_type}.${name}" "$tf_id"
         fi
     done
-    changes=$(terraform plan -json -var-file=${env}.tfvars -out output | tail -n 1 | jq -r '.changes')
-    to_add=$(echo "$changes" | jq -r '.add')
-    to_change=$(echo "$changes" | jq -r '.change')
-    to_import=$(echo "$changes" | jq -r '.import')
-    to_remove=$(echo "$changes" | jq -r '.remove')
-    if [ $to_add -gt 0 ] || [ $to_change -gt 0 ] || [ $to_import -gt 0 ] || [ $to_remove -gt 0 ]; then
-        echo "CHANGES DETECTED. Exiting."
-        terraform show output
-        exit 1
-    fi
+    # changes=$(terraform plan -json -var-file=${env}.tfvars -out output | tail -n 1 | jq -r '.changes')
+    # to_add=$(echo "$changes" | jq -r '.add')
+    # to_change=$(echo "$changes" | jq -r '.change')
+    # to_import=$(echo "$changes" | jq -r '.import')
+    # to_remove=$(echo "$changes" | jq -r '.remove')
+    # if [ $to_add -gt 0 ] || [ $to_change -gt 0 ] || [ $to_import -gt 0 ] || [ $to_remove -gt 0 ]; then
+    #     echo "CHANGES DETECTED. Exiting."
+    #     terraform show output
+    #     exit 1
+    # fi
 popd
 
 pushd $this_directory/..

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -56,7 +56,7 @@ pushd $this_directory/../stacks/cf
     read user_input
 
     # Dual provider with v3 tf
-    git checkout 7749388b8db0d6f0c325d2393af77ccbb63f0295
+    git checkout 1ab655c7ddf9ffdf346870dc2ca32bf20d8c1caf
 
     if [[ "$env" == "dev" ]]; then
         backend_config_key="cf-development/terraform.tfstate"

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -37,7 +37,7 @@ pushd $this_directory/../stacks/cf
 
     root_addresses=$(cat existing.json | jq -r '.values.root_module.resources[] | select(.provider_name == "registry.terraform.io/cloudfoundry-community/cloudfoundry") | .address')
     module_addresses=$(cat existing.json | jq -r '.values.root_module.child_modules[].resources[] | select(.provider_name == "registry.terraform.io/cloudfoundry-community/cloudfoundry") | .address')
-    addresses="${root_addresses}\n${module_addresses}" 
+    addresses="${root_addresses} ${module_addresses}" 
     for address in $addresses; do
         existing_type=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.resources[] | select(.address==$address) | .type')
         case $existing_type in

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -9,6 +9,8 @@ env=$1
 
 this_directory=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+source $this_directory/sensitive.cfg
+
 pushd $this_directory/../stacks/cf
     git checkout d7c0aaefe5db36a530d2190713e5fb30c99fd969
 

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -12,7 +12,7 @@ this_directory=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pw
 source $this_directory/sensitive.cfg
 
 pushd $this_directory/../stacks/cf
-    git checkout d7c0aaefe5db36a530d2190713e5fb30c99fd969
+    git checkout 2389b98bb44dd870224d7725900d6196eb6f02d5
 
     # # Add provider
     if [[ "$env" == "dev" ]]; then

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -10,6 +10,7 @@ env=$1
 this_directory=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 pushd $this_directory/../stacks/cf
+    git checkout d7c0aaefe5db36a530d2190713e5fb30c99fd969
 
     # # Add provider
     if [[ "$env" == "dev" ]]; then
@@ -29,7 +30,6 @@ pushd $this_directory/../stacks/cf
         "-backend-config=region=us-gov-west-1"
     )
     terraform init -upgrade "${init_args[@]}"
-    git checkout d7c0aaefe5db36a530d2190713e5fb30c99fd969
 
     terraform show -json > existing.json
 

--- a/terraform/scripts/update-provider.sh
+++ b/terraform/scripts/update-provider.sh
@@ -78,7 +78,11 @@ pushd $this_directory/../stacks/cf
 
 
     for address in $addresses; do
-        if [[ "$address" =~ ^data* ]]; then
+        mode=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.resources[] | select(.address==$address) | .mode')
+        if [ -z "$mode" ]; then
+            mode=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.child_modules[].resources[] | select(.address==$address) | .mode')
+        fi 
+        if [[ "data" == "$mode" ]] || [[ "$address" =~ ^data* ]]; then
             echo "Skipping import of data object: $address"
         else
             existing_type=$(cat existing.json | jq -r --arg address "$address" '.values.root_module.resources[] | select(.address==$address) | .type')

--- a/terraform/stacks/cf/apps.tf
+++ b/terraform/stacks/cf/apps.tf
@@ -3,8 +3,4 @@ module "test_cdn" {
   source          = "../../modules/test_cdn"
   iaas_stack_name = var.iaas_stack_name
   organization_id = cloudfoundry_org.cloud-gov.id
-
-  providers = {
-    cloudfoundry = cloudfoundry
-  }
 }

--- a/terraform/stacks/cf/apps.tf
+++ b/terraform/stacks/cf/apps.tf
@@ -2,5 +2,5 @@ module "test_cdn" {
   count           = var.iaas_stack_name == "development" ? 0 : 1
   source          = "../../modules/test_cdn"
   iaas_stack_name = var.iaas_stack_name
-  organization_id = cloudfoundry_org.cloud-gov.id
+  organization_name = cloudfoundry_org.cloud-gov.name
 }

--- a/terraform/stacks/cf/asg.tf
+++ b/terraform/stacks/cf/asg.tf
@@ -104,8 +104,11 @@ resource "cloudfoundry_security_group" "dns" {
       log         = false
     },
   ]
-  staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
-  running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
+  # cloudfoundry_space.uaa-extras.id
+  # cloudfoundry_space.dashboard.id
+  # cloudfoundry_space.services.id
+  staging_spaces = [cloudfoundry_space.cg-ui.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
+  running_spaces = [cloudfoundry_space.cg-ui.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
 }
 
 # New dns asg to apply to spaces individually, not globally.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the test_cdn module to use the latest v3 version of the cf terraform provider. 
- Updates the asg space assignments to match the current state of the staging environment.

- The terraform/scripts/update-provider.sh script is only used for the migration and will be deleted after the updates are rolled through production.

## security considerations

None
