### PR TITLE
Prevent overwrite of manually configured security groups

### DIFF
--- a/terraform/stacks/cf/asg.tf
+++ b/terraform/stacks/cf/asg.tf
@@ -29,10 +29,13 @@ resource "cloudfoundry_security_group" "public_networks" {
       log         = false
     },
   ]
+}
+
+resource "cloudfoundry_security_group_space_bindings" "public_networks_bindings" {
+  security_group = cloudfoundry_security_group.public_networks.id
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
 }
-
 
 # New public_networks asg to apply to spaces individually, not globally.
 resource "cloudfoundry_security_group" "public_networks_egress" {
@@ -104,11 +107,12 @@ resource "cloudfoundry_security_group" "dns" {
       log         = false
     },
   ]
-  # cloudfoundry_space.uaa-extras.id
-  # cloudfoundry_space.dashboard.id
-  # cloudfoundry_space.services.id
-  staging_spaces = [cloudfoundry_space.cg-ui.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
-  running_spaces = [cloudfoundry_space.cg-ui.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
+}
+
+resource "cloudfoundry_security_group_space_bindings" "dns_bindings" {
+  security_group = cloudfoundry_security_group.dns.id
+  staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
+  running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
 }
 
 # New dns asg to apply to spaces individually, not globally.
@@ -230,6 +234,10 @@ resource "cloudfoundry_security_group" "trusted_local_networks" {
   # RDS access for postgres, mysql, mssql, oracle
   rules = local.trusted_local_networks_rules
 
+}
+
+resource "cloudfoundry_security_group_space_bindings" "trusted_local_networks_bindings" {
+  security_group = cloudfoundry_security_group.trusted_local_networks.id
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.email.id]
 }
@@ -344,6 +352,10 @@ resource "cloudfoundry_security_group" "brokers" {
     description = "AWS Metadata Service"
     log         = false
   }]
+}
+
+resource "cloudfoundry_security_group_space_bindings" "brokers_bindings" {
+  security_group = cloudfoundry_security_group.brokers.id
   running_spaces = [cloudfoundry_space.services.id]
 }
 
@@ -355,6 +367,10 @@ resource "cloudfoundry_security_group" "smtp" {
     protocol    = "tcp"
     ports       = "25"
   }]
+}
+
+resource "cloudfoundry_security_group_space_bindings" "smtp_bindings" {
+  security_group = cloudfoundry_security_group.smtp.id
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.email.id]
 }
 

--- a/terraform/stacks/cf/asg.tf
+++ b/terraform/stacks/cf/asg.tf
@@ -31,7 +31,7 @@ resource "cloudfoundry_security_group" "public_networks" {
   ]
 }
 
-resource "cloudfoundry_security_group_space_bindings" "public_networks_bindings" {
+resource "cloudfoundry_security_group_space_bindings" "public_networks" {
   security_group = cloudfoundry_security_group.public_networks.id
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
@@ -88,6 +88,12 @@ resource "cloudfoundry_security_group" "public_networks_egress" {
   ]
 }
 
+resource "cloudfoundry_security_group_space_bindings" "public_networks_egress" {
+  security_group = cloudfoundry_security_group.public_networks_egress.id
+  staging_spaces = [cloudfoundry_space.opensearch-dashboards-proxy.id]
+  running_spaces = [cloudfoundry_space.opensearch-dashboards-proxy.id]
+}
+
 resource "cloudfoundry_security_group" "dns" {
   name                     = "dns"
   globally_enabled_running = true
@@ -109,7 +115,7 @@ resource "cloudfoundry_security_group" "dns" {
   ]
 }
 
-resource "cloudfoundry_security_group_space_bindings" "dns_bindings" {
+resource "cloudfoundry_security_group_space_bindings" "dns" {
   security_group = cloudfoundry_security_group.dns.id
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.external_domain_broker_tests.id, cloudfoundry_space.email.id]
@@ -236,7 +242,7 @@ resource "cloudfoundry_security_group" "trusted_local_networks" {
 
 }
 
-resource "cloudfoundry_security_group_space_bindings" "trusted_local_networks_bindings" {
+resource "cloudfoundry_security_group_space_bindings" "trusted_local_networks" {
   security_group = cloudfoundry_security_group.trusted_local_networks.id
   staging_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.email.id]
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.opensearch-dashboards-proxy.id, cloudfoundry_space.email.id]
@@ -354,7 +360,7 @@ resource "cloudfoundry_security_group" "brokers" {
   }]
 }
 
-resource "cloudfoundry_security_group_space_bindings" "brokers_bindings" {
+resource "cloudfoundry_security_group_space_bindings" "brokers" {
   security_group = cloudfoundry_security_group.brokers.id
   running_spaces = [cloudfoundry_space.services.id]
 }
@@ -369,7 +375,7 @@ resource "cloudfoundry_security_group" "smtp" {
   }]
 }
 
-resource "cloudfoundry_security_group_space_bindings" "smtp_bindings" {
+resource "cloudfoundry_security_group_space_bindings" "smtp" {
   security_group = cloudfoundry_security_group.smtp.id
   running_spaces = [cloudfoundry_space.services.id, cloudfoundry_space.dashboard.id, cloudfoundry_space.cg-ui.id, cloudfoundry_space.uaa-extras.id, cloudfoundry_space.cspr-collector.id, cloudfoundry_space.email.id]
 }

--- a/terraform/stacks/cf/orgs.tf
+++ b/terraform/stacks/cf/orgs.tf
@@ -6,6 +6,10 @@ resource "cloudfoundry_org" "acceptance_tests" {
   name = "cloud-gov-acceptance-tests"
 }
 
+data "cloudfoundry_org" "cloud-gov-operators" {
+  name = "cloud-gov-operators"
+}
+
 # Federalist/Pages
 
 data "cloudfoundry_org" "gsa-18f-federalist" {

--- a/terraform/stacks/cf/quotas.tf
+++ b/terraform/stacks/cf/quotas.tf
@@ -4,7 +4,7 @@ resource "cloudfoundry_org_quota" "default-tts" {
   total_memory             = 81920
   total_routes             = 1000
   total_services           = 200
-  orgs                     = [cloudfoundry_org.cloud-gov.id, cloudfoundry_org.acceptance_tests.id]
+  orgs                     = [cloudfoundry_org.cloud-gov.id, cloudfoundry_org.acceptance_tests.id, data.cloudfoundry_org.cloud-gov-operators.id]
 }
 
 # Federalist/ Pages


### PR DESCRIPTION
## Changes proposed in this pull request:

- **Prevents terraform from overwriting user configured space security groups.**

Resource `cloudfoundry_security_group`: The `running_spaces` and `staging_spaces` properties represent the actual state of space security group assignments, including those manually configured.  On import of this resource, all security group assignments are pulled into terraform. Manual changes made by users would therefore be overwritten. These properties should not be used. 

Resource `cloudfoundry_security_group_space_bindings`: This resource does not overwrite manually configured space security group bindings. It is not importable (hence the required state surgery mentioned below). 

_Note: this change must be made in parallel with manual state surgery. This surgery is complete in dev and will be completed in each environment as the change is propagated._

- **Assigns the `default-tts` quota to the `cloud-gov-operators` org. This assignment exists in production.**

_Note the quota is created in this terraform but the organization is not._

## security considerations

None
