### PR TITLE
Add isolated diego cells for devtools

### DIFF
--- a/bosh/opsfiles/scaling-development.yml
+++ b/bosh/opsfiles/scaling-development.yml
@@ -148,10 +148,10 @@
 
 
 # iso-segs
-#- type: replace
-#  path: /instance_groups/name=diego-cell-iso-seg1/vm_type
-#  value: r6i.4xlarge
-#
-#- type: replace
-#  path: /instance_groups/name=diego-cell-iso-seg1/instances
-#  value: 2
+- type: replace
+  path: /instance_groups/name=diego-cell-iso-seg-devtools/vm_type
+  value: t3.large
+
+- type: replace
+  path: /instance_groups/name=diego-cell-iso-seg-devtools/instances
+  value: 1

--- a/bosh/opsfiles/scaling-production.yml
+++ b/bosh/opsfiles/scaling-production.yml
@@ -150,3 +150,12 @@
 - type: replace
   path: /instance_groups/name=rotate-cc-database-key/vm_type
   value: t3.medium
+
+# iso-segs
+- type: replace
+  path: /instance_groups/name=diego-cell-iso-seg-devtools/vm_type
+  value: r6i.2xlarge
+
+- type: replace
+  path: /instance_groups/name=diego-cell-iso-seg-devtools/instances
+  value: 3

--- a/bosh/opsfiles/scaling-staging.yml
+++ b/bosh/opsfiles/scaling-staging.yml
@@ -146,3 +146,12 @@
 - type: replace
   path: /instance_groups/name=rotate-cc-database-key/vm_type
   value: t3.medium
+
+# iso-segs
+- type: replace
+  path: /instance_groups/name=diego-cell-iso-seg-devtools/vm_type
+  value: r6i.2xlarge
+
+- type: replace
+  path: /instance_groups/name=diego-cell-iso-seg-devtools/instances
+  value: 1

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -51,7 +51,7 @@ jobs:
         image: general-task
         file: cf-manifests/ci/create-diego-cell-iso-seg.yml
         params:
-          ISO_SEG_NAMES: "" #((names_of_iso_segs_development))    # Value in credhub
+          ISO_SEG_NAMES: ((names_of_iso_segs_development))
       - put: cf-deployment-development
         params: &deploy-params
           manifest: cf-deployment/cf-deployment.yml
@@ -612,7 +612,7 @@ jobs:
         image: general-task
         file: cf-manifests/ci/create-diego-cell-iso-seg.yml
         params:
-          ISO_SEG_NAMES: "" #((names_of_iso_segs_staging))    # Value in credhub
+          ISO_SEG_NAMES: ((names_of_iso_segs_staging))
       - put: cf-deployment-staging
         params:
           <<: *deploy-params
@@ -1172,7 +1172,7 @@ jobs:
         image: general-task
         file: cf-manifests/ci/create-diego-cell-iso-seg.yml
         params:
-          ISO_SEG_NAMES: "" #((names_of_iso_segs_production))    # Value in credhub
+          ISO_SEG_NAMES: ((names_of_iso_segs_production))
       - put: cf-deployment-production
         params: &prod-deploy-params
           <<: *deploy-params
@@ -1288,7 +1288,7 @@ jobs:
         image: general-task
         file: cf-manifests/ci/create-diego-cell-iso-seg.yml
         params:
-          ISO_SEG_NAMES: "" #((names_of_iso_segs_production))    # Value in credhub
+          ISO_SEG_NAMES: ((names_of_iso_segs_production))
       - put: cf-deployment-production
         params:
           <<: *prod-deploy-params

--- a/terraform/stacks/cf/iso.tf
+++ b/terraform/stacks/cf/iso.tf
@@ -11,7 +11,7 @@ resource "cloudfoundry_isolation_segment_entitlement" "platform" {
 }
 
 resource "cloudfoundry_isolation_segment" "devtools" {
-  name = "devtools"
+  name = "diego-cell-iso-seg-devtools"
 }
 
 resource "cloudfoundry_isolation_segment_entitlement" "devtools" {

--- a/terraform/stacks/cf/iso.tf
+++ b/terraform/stacks/cf/iso.tf
@@ -14,10 +14,10 @@ resource "cloudfoundry_isolation_segment" "devtools" {
   name = "diego-cell-iso-seg-devtools"
 }
 
-#resource "cloudfoundry_isolation_segment_entitlement" "devtools" {
-#  segment = cloudfoundry_isolation_segment.devtools.id
-#  orgs = [
-#    cloudfoundry_org.cloud-gov-devtools.id
-#  ]
-#  default = true
-#}
+resource "cloudfoundry_isolation_segment_entitlement" "devtools" {
+  segment = cloudfoundry_isolation_segment.devtools.id
+  orgs = [
+    cloudfoundry_org.cloud-gov-devtools.id
+  ]
+  default = true
+}

--- a/terraform/stacks/cf/iso.tf
+++ b/terraform/stacks/cf/iso.tf
@@ -11,12 +11,10 @@ resource "cloudfoundry_isolation_segment_entitlement" "platform" {
 }
 
 resource "cloudfoundry_isolation_segment" "devtools" {
-  count = var.iaas_stack_name == "development" ? 1 : 0
-  name  = "devtools"
+  name = "devtools"
 }
 
 resource "cloudfoundry_isolation_segment_entitlement" "devtools" {
-  count   = var.iaas_stack_name == "development" ? 1 : 0
   segment = cloudfoundry_isolation_segment.devtools.id
   orgs = [
     cloudfoundry_org.cloud-gov-devtools.id

--- a/terraform/stacks/cf/iso.tf
+++ b/terraform/stacks/cf/iso.tf
@@ -9,3 +9,17 @@ resource "cloudfoundry_isolation_segment_entitlement" "platform" {
   ]
   default = false
 }
+
+resource "cloudfoundry_isolation_segment" "devtools" {
+  count = var.iaas_stack_name == "development" ? 1 : 0
+  name  = "devtools"
+}
+
+resource "cloudfoundry_isolation_segment_entitlement" "devtools" {
+  count   = var.iaas_stack_name == "development" ? 1 : 0
+  segment = cloudfoundry_isolation_segment.devtools.id
+  orgs = [
+    cloudfoundry_org.cloud-gov-devtools.id
+  ]
+  default = false
+}

--- a/terraform/stacks/cf/iso.tf
+++ b/terraform/stacks/cf/iso.tf
@@ -14,10 +14,10 @@ resource "cloudfoundry_isolation_segment" "devtools" {
   name = "diego-cell-iso-seg-devtools"
 }
 
-resource "cloudfoundry_isolation_segment_entitlement" "devtools" {
-  segment = cloudfoundry_isolation_segment.devtools.id
-  orgs = [
-    cloudfoundry_org.cloud-gov-devtools.id
-  ]
-  default = true
-}
+#resource "cloudfoundry_isolation_segment_entitlement" "devtools" {
+#  segment = cloudfoundry_isolation_segment.devtools.id
+#  orgs = [
+#    cloudfoundry_org.cloud-gov-devtools.id
+#  ]
+#  default = true
+#}

--- a/terraform/stacks/cf/iso.tf
+++ b/terraform/stacks/cf/iso.tf
@@ -19,5 +19,5 @@ resource "cloudfoundry_isolation_segment_entitlement" "devtools" {
   orgs = [
     cloudfoundry_org.cloud-gov-devtools.id
   ]
-  default = false
+  default = true
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- This change supports adding a `devtools` isolation segment to dev/stage/prod and mapping this to their "production" cf org.
- Leverages automation to generate iso segs based on upstream and our customizations laid out in https://github.com/cloud-gov/internal-docs/blob/f258ec118fc5a0d6401eca86a6d8d0242ad69925/docs/runbooks/Platform/adding-isolation-segments.md but also automate mapping the org to the iso seg.
- Part of https://github.com/cloud-gov/private/issues/2472
-

## security considerations
Secrets stored in credhub, just adding a single iso segment to dev/stage/prod
