### PR TITLE
Removed X-XSS-Protection as default header

### DIFF
--- a/bosh/opsfiles/router-logstash.yml
+++ b/bosh/opsfiles/router-logstash.yml
@@ -116,8 +116,6 @@
           value: "max-age=31536000"
         - name: "X-Content-Type-Options"
           value: "nosniff"
-        - name: "X-XSS-Protection"
-          value: "1; mode=block"
         - name: "Content-Type"
           value: "text/plain; charset=utf-8"
         - name: "X-Frame-Options"

--- a/bosh/opsfiles/router-main.yml
+++ b/bosh/opsfiles/router-main.yml
@@ -116,8 +116,6 @@
           value: "max-age=31536000"
         - name: "X-Content-Type-Options"
           value: "nosniff"
-        - name: "X-XSS-Protection"
-          value: "1; mode=block"
         - name: "Content-Type"
           value: "text/plain; charset=utf-8"
         - name: "X-Frame-Options"

--- a/bosh/opsfiles/secureproxy.yml
+++ b/bosh/opsfiles/secureproxy.yml
@@ -40,7 +40,7 @@
           host_whitelist:
           - hostname: api.((system_domain))
             exclude:
-              - ^/v2/info  
+              - ^/v2/info
               - ^/v3/info
           - hostname: dashboard.((system_domain))
             exclude: []
@@ -103,8 +103,6 @@
         value: "max-age=31536000"
       - name: "X-Content-Type-Options"
         value: "nosniff"
-      - name: "X-XSS-Protection"
-        value: "1; mode=block"
       - name: "Content-Type"
         value: "text/plain; charset=utf-8"
       - name: "X-Frame-Options"


### PR DESCRIPTION
## Changes proposed in this pull request:
- X-XSS is now deprecated
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection#security_considerations
-

## security considerations
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection#security_considerations