### PR TITLE
Adding wait to ds so async rds delete

### DIFF
--- a/ci/test-space-egress/clean.sh
+++ b/ci/test-space-egress/clean.sh
@@ -27,7 +27,7 @@ do
   cf delete-route $DOMAIN --hostname app-test-$space -f
 
   # Delete service instance db
-  cf delete-service $space-db -f
+  cf delete-service $space-db -f -w
 done
 
 ## Delete spaces


### PR DESCRIPTION
## Changes proposed in this pull request:
- add a `-w` for wait for the async rds db service deletion to take place to avoid [this](https://ci.fr.cloud.gov/teams/main/pipelines/deploy-cf/jobs/test-space-egress-development/builds/553)

## security considerations
n/a
