### PR TITLE
Declare scopes for billing UAA client

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -147,6 +147,7 @@
     authorized-grant-types: client_credentials
     authorities: cloud_controller.admin_read_only
     secret: ((billing-client-secret))
+    scope: usage.admin,usage.read
 
 - type: replace
   path: /variables/-


### PR DESCRIPTION
## Changes proposed in this pull request:

We are adding an admin API to the billing service. We will add Cloud.gov operators to the `usage.admin` group in UAA and the billing service will enforce authorization using the scope. `usage.read` is intended for the user-facing API, which is not yet implemented.

Related to https://github.com/cloud-gov/product/issues/3303.

## security considerations

Adds two new roles for accessing sensitive information to UAA. Cloud.gov operators will be granted access through an update to [this script](https://github.com/cloud-gov/cg-scripts/blob/main/cloudfoundry/make-cf-admin.sh). The billing service will JWT verification and require scope `usage.admin` to access admin routes. Granting customer access will be handled separately; method TBD. Customer verification/validation will work the same.