### PR TITLE
Permit client to create tokens with its own scopes

### DIFF
--- a/bosh/opsfiles/clients.yml
+++ b/bosh/opsfiles/clients.yml
@@ -145,7 +145,7 @@
   value:
     override: true
     authorized-grant-types: client_credentials
-    authorities: cloud_controller.admin_read_only
+    authorities: cloud_controller.admin_read_only,usage.admin,usage.read
     secret: ((billing-client-secret))
     scope: usage.admin,usage.read
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Useful for testing of the service while we work on a web frontend.

## security considerations
None additional. No other service respects these scopes and the billing service where this client is used can already read its own data.
