### PR TITLE
Add zap-scan user

### DIFF
--- a/bosh/opsfiles/users.yml
+++ b/bosh/opsfiles/users.yml
@@ -27,6 +27,19 @@
     name: autoscaler-password
     type: password
 
+# zap-scan user
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/scim/users/-
+  value:
+    name: zap-scan-user
+    password: ((zap-scan-password))
+    groups: [openid, cloud_controller.admin_read_only, scim.read, scim.write, uaa.user, pages.user, pages.support]
+- type: replace
+  path: /variables/-
+  value:
+    name: zap-scan-password
+    type: password
+
 # Sandbox Bot user
 # Note: this user is used by the acceptance tests, the sandbox-bot client is used inside the app and doesn't need the higher level of permissions
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add a cf user for zap-scan tool that can be used for Pages and Dashboard scans
- Part of https://github.com/cloud-gov/deploy-cf/issues/988
-

## security considerations
Password for new user account managed in Credhub
