### PR TITLE
Force older versions of CF to be available

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1529,6 +1529,7 @@ resources:
       uri: https://github.com/cloudfoundry/cf-deployment
       branch: main
       tag_filter: "v*"
+      version_depth: 8
 
   - name: cf-acceptance-tests
     type: git


### PR DESCRIPTION
## Changes proposed in this pull request:
- Force older versions of CF to be available, even when pinned, older version of CF can fall off
- Part of https://github.com/cloud-gov/product/issues/2836
-

## security considerations
None, forces concourse to keep a resource longer for cf-deployment
