### PR TITLE
revert java pin

### DIFF
--- a/bosh/opsfiles/api-defaults.yml
+++ b/bosh/opsfiles/api-defaults.yml
@@ -34,11 +34,3 @@
       restart_if_above_mb: 1024
       restart_if_consistently_above_mb: 768
       alert_if_above_mb: 768
-
-- type: replace
-  path: /releases/name=java-buildpack
-  value:
-    name: java-buildpack
-    version: 4.76.0
-    url: https://bosh.io/d/github.com/cloudfoundry/java-buildpack-release?v=4.76.0
-    sha1: 7f0a034209b3be44aff6e24453b21dcd5dffae87


### PR DESCRIPTION
## Changes proposed in this pull request:
- Didn't check if we were already on 4.77 so better to keep it same versus reverting
-
-

## security considerations
None