### PR TITLE
Pagination messes up with \n

### DIFF
--- a/ci/uaa-client-audit.sh
+++ b/ci/uaa-client-audit.sh
@@ -23,7 +23,7 @@ paginate() {
   while [ -n "${next_url}" ]; do
     page=$(cfcurl -s "${next_url}")
     next_url=$(echo -n "${page}" | jq -r '.pagination.next.href // ""')
-    results="${results}\n$(echo -n "${page}" | jq -r "${selector}")"
+    results="${results},$(echo -n "${page}" | jq -r "${selector}")"
   done
 
   echo "${results}"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Pairing with Robert, once you hit 50 service instances it calls out to pull in the next page and merge the results, which is comma delimited, not newline delimited.  You can see in the Concourse output the last two service instance guids smashed together with a `\n` between them which prevents the successful look of the service keys.
- Part of https://github.com/cloud-gov/product/issues/2836
-

## security considerations
Fixes uaa client check