### PR TITLE
removing capi pin/no longer needed

### DIFF
--- a/bosh/opsfiles/pin-capi.yml
+++ b/bosh/opsfiles/pin-capi.yml
@@ -1,4 +1,5 @@
 # Pin CAPI because of Service instance counts on space quotas
+# No longer used as of Aug 28, 2025 but leaving in place for future use/pin
 - type: replace
   path: /releases/name=capi
   value:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -124,7 +124,6 @@ jobs:
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/wazuh.yml
             - cf-manifests/bosh/opsfiles/pin-uaa.yml
-            - cf-manifests/bosh/opsfiles/pin-capi.yml
             - cf-manifests/bosh/opsfiles/add-hardened-stacks.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/development.yml
@@ -678,7 +677,6 @@ jobs:
             - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/pin-uaa.yml
-            - cf-manifests/bosh/opsfiles/pin-capi.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/staging.yml
             - terraform-secrets/terraform.yml
@@ -1189,7 +1187,6 @@ jobs:
             - cf-manifests/bosh/opsfiles/diego-cpu-entitlement-diego-cell.yml
             - cf-manifests/bosh/opsfiles/aggregate_drains.yml
             - cf-manifests/bosh/opsfiles/pin-uaa.yml
-            - cf-manifests/bosh/opsfiles/pin-capi.yml
           vars_files:
             - cf-manifests/bosh/varsfiles/production.yml
             - terraform-secrets/terraform.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove ops file from pipeline pinning capi now that issue is resolved

## security considerations
n/a
